### PR TITLE
IE11 support

### DIFF
--- a/packages/mf/src/utils/dynamic-federation.ts
+++ b/packages/mf/src/utils/dynamic-federation.ts
@@ -54,7 +54,7 @@ export function loadRemoteEntry(remoteEntry: string, remoteName: string): Promis
             resolve(); 
         }
 
-        document.body.append(script);
+        document.body.appendChild(script);
     });
 }
 


### PR DESCRIPTION
Plugin is not loading microfrontend modules on IE11 due to the lack of **append** function on DOM elements.

**appendChild** function is suitable and IE11 loads correctly the microfrontend.