### PR TITLE
fix(schematics): fix port type in 'config' schematics

### DIFF
--- a/packages/mf/src/schematics/mf/schema.json
+++ b/packages/mf/src/schematics/mf/schema.json
@@ -14,7 +14,7 @@
       "x-prompt": "Project name (press enter for default project)"
     },
     "port": {
-      "type": "string",
+      "type": "number",
       "description": "The port to use for the federated module (remote, micro frontend, etc.)",
       "x-prompt": "Port to use",
       "$default": {


### PR DESCRIPTION
`ng generate @angular-architects/module-federation:config --project=feature-payments --port=5001 --no-interactive --dry-run`
cause error: `Property 'port' does not match the schema. '5001' should be a 'string'.`