### PR TITLE
fix(utils): make rootPath a paramater for registering mappings

### DIFF
--- a/libs/mf/src/utils/shared-mappings.ts
+++ b/libs/mf/src/utils/shared-mappings.ts
@@ -4,110 +4,119 @@ import * as fs from 'fs';
 import * as JSON5 from 'json5';
 
 interface Library {
-    key: string;
-    path: string;
-    version?: string;
+  key: string;
+  path: string;
+  version?: string;
 }
 
 export class SharedMappings {
-    private mappings: Library[] = [];
+  private mappings: Library[] = [];
 
-    register(tsConfigPath: string, shared: string[] = null): void {
-        if (!path.isAbsolute(tsConfigPath)) {
-            throw new Error('SharedMappings.register: tsConfigPath needs to be an absolute path!');
-        }
-
-        const tsConfig = JSON5.parse(fs.readFileSync(tsConfigPath, { encoding: 'utf-8' }));
-        const mappings = tsConfig?.compilerOptions?.paths;
-        const rootPath = path.normalize(path.dirname(tsConfigPath));
-
-        if (!mappings) {
-            return;
-        }
-
-        for (const key in mappings) {
-            const libPath = path.normalize(path.join(rootPath, mappings[key][0]));
-            const version = this.getPackageVersion(libPath);
-
-            if (shared && shared.includes(key)) {
-                this.mappings.push({
-                    key,
-                    path: libPath,
-                    version,
-                });
-            }
-        }
+  register(
+    tsConfigPath: string,
+    shared: string[] = null,
+    rootPath: string = path.normalize(path.dirname(tsConfigPath))
+  ): void {
+    if (!path.isAbsolute(tsConfigPath)) {
+      throw new Error(
+        'SharedMappings.register: tsConfigPath needs to be an absolute path!'
+      );
     }
 
-    private getPackageVersion(libPath: string) {
-        if (libPath.endsWith('.ts')) {
-            libPath = path.dirname(libPath);
-        }
+    const tsConfig = JSON5.parse(
+      fs.readFileSync(tsConfigPath, { encoding: 'utf-8' })
+    );
+    const mappings = tsConfig?.compilerOptions?.paths;
 
-        const packageJsonPath = path.join(libPath, '..', 'package.json');
-        if (fs.existsSync(packageJsonPath)) {
-            const packageJson = JSON5.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf-8' }));
-
-            return packageJson.version ?? null;
-        }
-        return null;
+    if (!mappings) {
+      return;
     }
 
-    getPlugin(): NormalModuleReplacementPlugin {
-        return new NormalModuleReplacementPlugin(/./, (req) => {
-            const from = req.context;
-            const to = path.normalize(path.join(req.context, req.request));
+    for (const key in mappings) {
+      const libPath = path.normalize(path.join(rootPath, mappings[key][0]));
+      const version = this.getPackageVersion(libPath);
 
-            if (!req.request.startsWith('.')) return;
-
-            for (const m of this.mappings) {
-                const libFolder = path.normalize(path.dirname(m.path));
-                if (!from.startsWith(libFolder) && to.startsWith(libFolder)) {
-                    req.request = m.key;
-                    // console.log('remapping', { from, to, libFolder });
-                }
-            }
+      if (shared && shared.includes(key)) {
+        this.mappings.push({
+          key,
+          path: libPath,
+          version,
         });
+      }
+    }
+  }
+
+  private getPackageVersion(libPath: string) {
+    if (libPath.endsWith('.ts')) {
+      libPath = path.dirname(libPath);
     }
 
-    getAliases(): Record<string, string> {
-        const result = {};
+    const packageJsonPath = path.join(libPath, '..', 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON5.parse(
+        fs.readFileSync(packageJsonPath, { encoding: 'utf-8' })
+      );
 
-        for (const m of this.mappings) {
-            result[m.key] = m.path;
+      return packageJson.version ?? null;
+    }
+    return null;
+  }
+
+  getPlugin(): NormalModuleReplacementPlugin {
+    return new NormalModuleReplacementPlugin(/./, (req) => {
+      const from = req.context;
+      const to = path.normalize(path.join(req.context, req.request));
+
+      if (!req.request.startsWith('.')) return;
+
+      for (const m of this.mappings) {
+        const libFolder = path.normalize(path.dirname(m.path));
+        if (!from.startsWith(libFolder) && to.startsWith(libFolder)) {
+          req.request = m.key;
+          // console.log('remapping', { from, to, libFolder });
         }
+      }
+    });
+  }
 
-        return result;
+  getAliases(): Record<string, string> {
+    const result = {};
+
+    for (const m of this.mappings) {
+      result[m.key] = m.path;
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    getDescriptors(eager?: boolean): object {
-        const result = {};
+    return result;
+  }
 
-        for (const m of this.mappings) {
-            result[m.key] = {
-                requiredVersion: false,
-                eager,
-            };
-        }
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  getDescriptors(eager?: boolean): object {
+    const result = {};
 
-        return result;
+    for (const m of this.mappings) {
+      result[m.key] = {
+        requiredVersion: false,
+        eager,
+      };
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    getDescriptor(mappedPath: string, requiredVersion: string = null): object {
-        const lib = this.mappings.find((m) => m.key === mappedPath);
+    return result;
+  }
 
-        if (!lib) {
-            throw new Error('No mapping found for ' + mappedPath + ' in tsconfig');
-        }
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  getDescriptor(mappedPath: string, requiredVersion: string = null): object {
+    const lib = this.mappings.find((m) => m.key === mappedPath);
 
-        return {
-            [mappedPath]: {
-                import: lib.path,
-                version: lib.version ?? undefined,
-                requiredVersion: requiredVersion ?? false,
-            },
-        };
+    if (!lib) {
+      throw new Error('No mapping found for ' + mappedPath + ' in tsconfig');
     }
+
+    return {
+      [mappedPath]: {
+        import: lib.path,
+        version: lib.version ?? undefined,
+        requiredVersion: requiredVersion ?? false,
+      },
+    };
+  }
 }


### PR DESCRIPTION
## Description

Change `register` method in `SharedMappings` to accept `rootPath` as a parameter. Set the default to the original value, which was to determine the dirname from the passed in `tsconfigPath`.

## Motivation

Some apps may use a TSConfig file that lives in a different directory than the root of the repo. Therefore, there needs to be a method to override the `rootPath` for those apps. e.g. Buildable libs in Nx forces Nx to generate a new TSConfig at build time which contains the new path mappings to the built source files. This generated TSConfig lives in the app's directory, not at the root of the repo. (related issue https://github.com/nrwl/nx/issues/6923)

This change provides consumers with the flexibility to override the `rootPath` but places the onus on the consumer to ensure that the override works. All other consumers should be unaffected.