### PR TITLE
fix: micro frontend routing via browser back button + replaced deprecated substr()

### DIFF
--- a/libs/mf-tools/src/lib/web-components/router-utils.ts
+++ b/libs/mf-tools/src/lib/web-components/router-utils.ts
@@ -20,20 +20,17 @@ export function endsWith(prefix: string): UrlMatcher {
     };
 }
 
-export function connectRouter(router: Router, useHash = false): void {
-    let url: string;
+export function connectRouter(router: Router, useHash: boolean = false): void {
     if (!useHash) {
-        url = `${location.pathname.substr(1)}${location.search}`;
-        router.navigateByUrl(url);
+        router.navigateByUrl(`${location.pathname.substring(1)}${location.search}`);
         window.addEventListener('popstate', () => {
-            router.navigateByUrl(url);
+            router.navigateByUrl(`${location.pathname.substring(1)}${location.search}`);
         });
     }
     else {
-        url = `${location.hash.substr(1)}${location.search}`;
-        router.navigateByUrl(url);
+        router.navigateByUrl(`${location.hash.substring(1)}${location.search}`);
         window.addEventListener('hashchange', () => {
-            router.navigateByUrl(url);
+            router.navigateByUrl(`${location.hash.substring(1)}${location.search}`);
         });
     }
 }


### PR DESCRIPTION
Angular Routing in micro frontends was broken if the back button of the browser was used.