### PR TITLE
fix: remove validation errors in ModuleFederationPlugin because of 'includeSecondaries' property

### DIFF
--- a/libs/mf/src/utils/share-utils.ts
+++ b/libs/mf/src/utils/share-utils.ts
@@ -273,8 +273,9 @@ export function share(shareObjects: Config, packageJsonPath = ''): Config {
 
     if (shareObject.includeSecondaries) {
       includeSecondaries = shareObject.includeSecondaries;
-      delete shareObject.includeSecondaries;
     }
+    
+    delete shareObject.includeSecondaries;
 
     result[key] = shareObject;
 


### PR DESCRIPTION
always delete 'includeSecondaries' property from shareObject as webpack otherwise throws a validation error if it finds properties that are not expected in the share configuration