### PR TITLE
docs(README): correct Nx usage typo

### DIFF
--- a/libs/mf/README.md
+++ b/libs/mf/README.md
@@ -72,8 +72,8 @@ If you start from the scratch, `ng add` will take care of these settings.
 
 ### Nx
 
-1. `npm install @angular-architects/module-federation`
-2. `ng g @angular-architects/module-federation:init`
+1. `npm install --save-dev @angular-architects/module-federation`
+2. `nx g @angular-architects/module-federation:init`
 3. Adjust the generated `webpack.config.js` file
 4. Repeat this for further projects in your workspace (if needed)
 


### PR DESCRIPTION
LN76 of `README.md` mentions using the Angular CLI to initialize the plugin for an Nx monorepo:

```
ng g @angular-architects/module-federation:init
```

This should use the Nx CLI to run the command:

```
nx g @angular-architects/module-federation:init
```

Failing to do so results in an error:

```
Error: This command is not available when running the Angular CLI outside a workspace.
```

Additionally, it makes sense to add this plugin as a development dependency of the workspace.