### PR TITLE
docs: updates web component instruction

### DIFF
--- a/libs/mf-tools/README.md
+++ b/libs/mf-tools/README.md
@@ -196,8 +196,24 @@ RouterModule.forRoot([
 
 ## Directly Loading a Web Component via Module Federation
 
-The `WebComponentWrapper` can also be used as a traditional component:
+The `WebComponentWrapper` can also be used as a traditional component, as it is a part of `ModuleFederationToolsModule`:
 
+```typescript
+// angular-component.module.ts
+import { ModuleFederationToolsModule } from "@angular-architects/module-federation-tools";
+
+
+@NgModule({
+  declarations: [ ... ],
+  exports: [ ... ],
+  imports: [
+    ...
+    ModuleFederationToolsModule,
+  ],
+})
+export class AngularComponentModule {}
+```
+In the template:
 ```html
 <mft-wc-wrapper [options]="item"></mft-wc-wrapper>
 ```
@@ -233,6 +249,16 @@ events = {
 ></mft-wc-wrapper>
 ```
 
+Remember that in order to use props we need to access html web compnent durnig render and extract them. (React example)
+
+```typescript
+class MfElement extends HTMLElement {
+  connectedCallback() {
+    const props = this["props"];
+    ReactDOM.render(<App {...props} />, this);
+  }
+}
+```
 ## Some Additional Details
 
 > In a multi version micro frontend strategy, it is important to load the zone.js bundle to the window object only once. Also, one need to make sure that only one instance of the ngZone is used by all the micro frontends.


### PR DESCRIPTION
Hi,

I have been having issues while trying to implement react web component mf into an angular shell. I feel that the fact that the ModuleFederationToolsModule is there and needs to be imported may be valid to include in the documentation.

Similarly would be nice to have information on how to access props to communicate in between apps. 