### PR TITLE
Fix localhost links in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7299,7 +7299,7 @@
     },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
-      "resolved": "http://localhost:4873/@types%2feslint/-/eslint-8.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2feslint/-/eslint-8.4.10.tgz",
       "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "license": "MIT",
       "dependencies": {
@@ -8093,7 +8093,7 @@
     },
     "node_modules/acron": {
       "version": "1.0.5",
-      "resolved": "http://localhost:4873/acron/-/acron-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/acron/-/acron-1.0.5.tgz",
       "integrity": "sha512-Jm3uey9PSUl5k9RsjBSfDJG35nG0vd9B4FUCV1J/NeVHDQ5HJPVpAhmGrPYtPKh0gLhEUIEy4DKqBy/p60B+4Q==",
       "license": "MIT",
       "dependencies": {
@@ -10732,7 +10732,7 @@
     },
     "node_modules/cypress/node_modules/@types/node": {
       "version": "12.12.50",
-      "resolved": "http://localhost:4873/@types%2fnode/-/node-12.12.50.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fnode/-/node-12.12.50.tgz",
       "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
       "dev": true,
       "license": "MIT"
@@ -27476,7 +27476,7 @@
     },
     "@types/eslint": {
       "version": "8.4.10",
-      "resolved": "http://localhost:4873/@types%2feslint/-/eslint-8.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2feslint/-/eslint-8.4.10.tgz",
       "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "requires": {
         "@types/estree": "*",
@@ -28120,7 +28120,7 @@
     },
     "acron": {
       "version": "1.0.5",
-      "resolved": "http://localhost:4873/acron/-/acron-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/acron/-/acron-1.0.5.tgz",
       "integrity": "sha512-Jm3uey9PSUl5k9RsjBSfDJG35nG0vd9B4FUCV1J/NeVHDQ5HJPVpAhmGrPYtPKh0gLhEUIEy4DKqBy/p60B+4Q==",
       "requires": {
         "lodash": "^4.17.11"
@@ -30025,7 +30025,7 @@
       "dependencies": {
         "@types/node": {
           "version": "12.12.50",
-          "resolved": "http://localhost:4873/@types%2fnode/-/node-12.12.50.tgz",
+          "resolved": "https://registry.npmjs.org/@types%2fnode/-/node-12.12.50.tgz",
           "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
           "dev": true
         },


### PR DESCRIPTION
in https://github.com/angular-architects/module-federation-plugin/commit/705e78d029877b42be22cff6206be21d2e1db7c4#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519 several links to some npm registry running on `localhost` ended up in the package-lock.json, which prevents the project from being installable. this fixes these links by manually rewriting them to the default npm registry.