### PR TITLE
Add license and repo fields where they were missing

### DIFF
--- a/libs/mf-runtime/package.json
+++ b/libs/mf-runtime/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@angular-architects/module-federation-runtime",
   "license": "MIT",
+  "repository": {
+    "type": "GitHub",
+    "url": "https://github.com/angular-architects/module-federation-plugin"
+  },
   "version": "15.0.3",
   "peerDependencies": {
     "@angular/common": ">=15.0.0",

--- a/libs/mf-tools/package.json
+++ b/libs/mf-tools/package.json
@@ -2,6 +2,10 @@
   "name": "@angular-architects/module-federation-tools",
   "version": "15.0.3",
   "license": "MIT",
+  "repository": {
+    "type": "GitHub",
+    "url": "https://github.com/angular-architects/module-federation-plugin"
+  },
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/core": ">=15.0.0",

--- a/libs/native-federation-core/package.json
+++ b/libs/native-federation-core/package.json
@@ -2,6 +2,11 @@
   "name": "@softarc/native-federation",
   "version": "1.1.0",
   "type": "commonjs",
+  "license": "MIT",
+  "repository": {
+    "type": "GitHub",
+    "url": "https://github.com/angular-architects/module-federation-plugin"
+  },
   "dependencies": {
     "json5": "^2.2.0",
     "npmlog": "^6.0.2",

--- a/libs/native-federation-esbuild/package.json
+++ b/libs/native-federation-esbuild/package.json
@@ -2,6 +2,11 @@
   "name": "@softarc/native-federation-esbuild",
   "version": "1.1.0",
   "type": "commonjs",
+  "license": "MIT",
+  "repository": {
+    "type": "GitHub",
+    "url": "https://github.com/angular-architects/module-federation-plugin"
+  },
   "dependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/libs/native-federation-runtime/package.json
+++ b/libs/native-federation-runtime/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@softarc/native-federation-runtime",
   "version": "1.1.0",
+  "license": "MIT",
+  "repository": {
+    "type": "GitHub",
+    "url": "https://github.com/angular-architects/module-federation-plugin"
+  },
   "peerDependencies": {},
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
I had quite a hard time figuring out the license and where the source code for @softarc/native-federation was located since all links I found related to it pointed to its [npmjs link](https://www.npmjs.com/package/@softarc/native-federation). This PR adds those fields to the package.json of all libraries that don't have those fields defined and assumes that all source code in this repo is licensed under the MIT license in the root of the repo.