### PR TITLE
Adds argument to disable opening all apps on startup

### DIFF
--- a/libs/mf/src/server/mf-dev-server.ts
+++ b/libs/mf/src/server/mf-dev-server.ts
@@ -16,9 +16,9 @@ function startCmd(name: string, cmd: string): void {
 }
 
 // tslint:disable-next-line: no-shadowed-variable
-function startApps(apps: ProjectInfo[]): void {
+function startApps(apps: ProjectInfo[], open: boolean): void {
   for (const app of apps) {
-    const cmd = `ng serve ${app.name} -o`;
+    const cmd = `ng serve ${app.name} --open ${open}`;
     print('DEVSVR', padding, app.name + ' ' + (app.port || '4200'));
     startCmd(app.name, cmd);
   }
@@ -30,6 +30,15 @@ if (!isWorkspace()) {
 }
 
 const [, , ...filter] = argv;
+
+let open = true;
+const dontOpenIndex = filter.indexOf("--open=false")
+
+if(dontOpenIndex >= 0) {
+  open = false;
+  filter.splice(dontOpenIndex, 1);
+}
+
 const startAll = filter.length === 0;
 
 const projects = readProjectInfos();
@@ -41,4 +50,4 @@ const apps = projects.filter(
 );
 padding = apps.reduce((acc, p) => Math.max(acc, p.name.length), 0);
 padding = Math.max(6, padding);
-startApps(apps);
+startApps(apps, open);


### PR DESCRIPTION
When --open=false is passed to the server, the Angular CLI won't open a new browser tab for each app that was started.
If the argument is not passed or passed with a different value to the server, the Angular CLI will open a new browser tab for each app that was started, to not break the current flow for users

The implementation of yargs could be considered to allow a simpler/cleaner way of implementing more arguments in the future

The next step could be to pass one ore app names into open argument to allow the ability to only open specific apps.
That would help with #155 