### PR TITLE
docs: fix markdown format on tutorial

### DIFF
--- a/libs/mf/tutorial/tutorial.md
+++ b/libs/mf/tutorial/tutorial.md
@@ -237,9 +237,8 @@ So far, we just hardcoded the URLs pointing to our Micro Frontends. However, in 
 
 2. Adjust the shell's `main.ts` (`projects/shell/src/main.ts`) as follows:
 
-   ```typescript
-   import { loadManifest } from '@angular-architects/module-federation';
-   ```
+```typescript
+import { loadManifest } from '@angular-architects/module-federation';
 
 loadManifest('assets/mf.manifest.json')
 .catch((err) => console.error('Error loading remote entries', err))
@@ -248,7 +247,7 @@ loadManifest('assets/mf.manifest.json')
 
 ````
 
-The imported `loadManifest` function also loads the remote entry points.
+   The imported `loadManifest` function also loads the remote entry points.
 
 3. Adjust the shell's lazy route pointing to the Micro Frontend as follows (`projects/shell/src/app/app.routes.ts`):
 


### PR DESCRIPTION
_Before_
> ![Screenshot 2023-03-28 at 19-24-58 angular-architects_module-federation-plugin](https://user-images.githubusercontent.com/6851095/228319969-a9811b38-1273-42cc-adcd-2b7c901936e1.png)

_After_
> ![Screenshot 2023-03-28 at 19-24-14 Editing module-federation-plugin_tutorial md at main · angular-architects_module-federation-plugin](https://user-images.githubusercontent.com/6851095/228319988-4c21239b-4400-4a1c-844e-2337beb2b5a3.png)

