### PR TITLE
module-federation-runtime doesn't have any prod dependency on angular

### DIFF
--- a/libs/mf-runtime/package.json
+++ b/libs/mf-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@angular-architects/module-federation-runtime",
   "license": "MIT",
   "version": "16.0.3",
-  "peerDependencies": {
+  "devDependencies": {
     "@angular/common": ">=16.0.0",
     "@angular/core": ">=16.0.0"
   },


### PR DESCRIPTION
It's possible to use module-federation-runtime with react and probably vue too but the peer dependency brings angular.