### PR TITLE
fix: explicitly depend on tslib

### DIFF
--- a/libs/native-federation-core/package.json
+++ b/libs/native-federation-core/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "json5": "^2.2.0",
     "npmlog": "^6.0.2",
+    "tslib": "^2.0.0",
     "@softarc/native-federation-runtime": "1.1.1"
   }
 }

--- a/libs/native-federation-esbuild/package.json
+++ b/libs/native-federation-esbuild/package.json
@@ -10,6 +10,7 @@
     "rollup-plugin-node-externals": "^4.1.1",
     "esbuild": "^0.15.5",
     "npmlog": "^6.0.2",
-    "acorn": "^8.8.1"
+    "acorn": "^8.8.1",
+    "tslib": "^2.0.0"
   }
 }


### PR DESCRIPTION
I'm trying to use this with Yarn's Plug'n'Play feature, which requires some explicitness about libraries. Since these libraries are build with `"importHelpers": true`, the resulting built code looks something like this (from `build.js` in `@softarc/native-federation`):

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const tslib_1 = require("tslib");
tslib_1.__exportStar(require("./src/build"), exports);
```

The attempt to use `tslib` without an explicit dependency on `tslib` in the `package.json`—it's a dependencies of the monorepo—causes a Yarn error when trying to execute the `require("tslib")`.

Thanks for all the work on this library!