### PR TITLE
doc: improve npm documentation

### DIFF
--- a/libs/mf-runtime/package.json
+++ b/libs/mf-runtime/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@angular-architects/module-federation-runtime",
-  "license": "MIT",
   "version": "16.0.3",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/mf-runtime"
+  },
   "peerDependencies": {
     "@angular/common": ">=16.0.0",
     "@angular/core": ">=16.0.0"

--- a/libs/mf-tools/package.json
+++ b/libs/mf-tools/package.json
@@ -2,6 +2,11 @@
   "name": "@angular-architects/module-federation-tools",
   "version": "16.0.3",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/mf-tools"
+  },
   "peerDependencies": {
     "@angular/common": ">=16.0.0",
     "@angular/core": ">=16.0.0",

--- a/libs/mf/package.json
+++ b/libs/mf/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "repository": {
     "type": "GitHub",
-    "url": "https://github.com/angular-architects/module-federation-plugin"
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/mf"
   },
   "author": {
     "name": "Manfred Steyer",

--- a/libs/native-federation-core/package.json
+++ b/libs/native-federation-core/package.json
@@ -2,6 +2,12 @@
   "name": "@softarc/native-federation",
   "version": "1.1.1",
   "type": "commonjs",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/native-federation-core"
+  },
   "dependencies": {
     "json5": "^2.2.0",
     "npmlog": "^6.0.2",

--- a/libs/native-federation-esbuild/package.json
+++ b/libs/native-federation-esbuild/package.json
@@ -2,6 +2,12 @@
   "name": "@softarc/native-federation-esbuild",
   "version": "1.1.1",
   "type": "commonjs",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/native-federation-esbuild"
+  },
   "dependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/libs/native-federation-runtime/package.json
+++ b/libs/native-federation-runtime/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@softarc/native-federation-runtime",
   "version": "1.1.1",
-  "peerDependencies": {},
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/native-federation-runtime"
+  },
   "dependencies": {
     "tslib": "^2.3.0"
   }

--- a/libs/native-federation/package.json
+++ b/libs/native-federation/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular-architects/module-federation-plugin"
+    "url": "https://github.com/angular-architects/module-federation-plugin",
+    "directory": "libs/native-federation"
   },
   "dependencies": {
     "@angular-architects/build-angular": "^14.2.0-next.0",


### PR DESCRIPTION
## Purpose

To help project discoverability from npmjs.org website this PR add missing repository entry in lib packages.

The screenshot below show the current state of documentation from npmjs.org website

![npmjs.org screenshot](https://github.com/angular-architects/module-federation-plugin/assets/2315749/8d71ee1f-fe70-4b94-be28-3ff67347cbb6)