### PR TITLE
1st attempt at i18n support

### DIFF
--- a/libs/native-federation-core/src/lib/core/bundle-exposed-and-mappings.ts
+++ b/libs/native-federation-core/src/lib/core/bundle-exposed-and-mappings.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/build-result-map';
 import { logger } from '../utils/logger';
 import { normalize } from '../utils/normalize';
+import { tryCopyFileToLocales } from '../utils/try-copy-file-to-locales';
 
 export interface ArtefactInfo {
   mappings: SharedInfo[];
@@ -55,9 +56,11 @@ export async function bundleExposedAndMappings(
   const sharedResult: Array<SharedInfo> = [];
 
   for (const item of shared) {
+    const outBaseName = lookupInResultMap(resultMap, item.outName);
+    const outFile = path.join(fedOptions.workspaceRoot, fedOptions.outputPath, outBaseName);
     sharedResult.push({
       packageName: item.key,
-      outFileName: lookupInResultMap(resultMap, item.outName),
+      outFileName: outBaseName,
       requiredVersion: '',
       singleton: true,
       strictVersion: false,
@@ -68,14 +71,17 @@ export async function bundleExposedAndMappings(
             entryPoint: normalize(path.normalize(item.fileName)),
           },
     });
+    tryCopyFileToLocales(outFile, fedOptions);
   }
 
   const exposedResult: Array<ExposesInfo> = [];
 
   for (const item of exposes) {
+    const outBaseName = lookupInResultMap(resultMap, item.outName);
+    const outFile = path.join(fedOptions.workspaceRoot, fedOptions.outputPath, outBaseName);
     exposedResult.push({
       key: item.key,
-      outFileName: lookupInResultMap(resultMap, item.outName),
+      outFileName: outBaseName,
       dev: !fedOptions.dev
         ? undefined
         : {
@@ -84,6 +90,7 @@ export async function bundleExposedAndMappings(
             ),
           },
     });
+    tryCopyFileToLocales(outFile, fedOptions);
   }
 
   return { mappings: sharedResult, exposes: exposedResult };

--- a/libs/native-federation-core/src/lib/core/bundle-shared.ts
+++ b/libs/native-federation-core/src/lib/core/bundle-shared.ts
@@ -8,6 +8,7 @@ import { FederationOptions } from './federation-options';
 import { copySrcMapIfExists } from '../utils/copy-src-map-if-exists';
 import { logger } from '../utils/logger';
 import { normalize } from '../utils/normalize';
+import { tryCopyFileToLocales } from '../utils/try-copy-file-to-locales';
 
 export async function bundleShared(
   config: NormalizedFederationConfig,
@@ -77,6 +78,7 @@ export async function bundleShared(
       const outFileName = path.basename(fileName);
       const cachedFile = path.join(cachePath, outFileName);
 
+      tryCopyFileToLocales(cachedFile, fedOptions);
       copyFileIfExists(cachedFile, fileName);
       copySrcMapIfExists(cachedFile, fileName);
     }

--- a/libs/native-federation-core/src/lib/core/federation-options.ts
+++ b/libs/native-federation-core/src/lib/core/federation-options.ts
@@ -7,5 +7,5 @@ export interface FederationOptions {
   dev?: boolean;
   watch?: boolean;
   packageJson?: string;
-  locales: string[];
+  locales?: string[];
 }

--- a/libs/native-federation-core/src/lib/core/federation-options.ts
+++ b/libs/native-federation-core/src/lib/core/federation-options.ts
@@ -7,4 +7,5 @@ export interface FederationOptions {
   dev?: boolean;
   watch?: boolean;
   packageJson?: string;
+  locales: string[];
 }

--- a/libs/native-federation-core/src/lib/core/write-federation-info.ts
+++ b/libs/native-federation-core/src/lib/core/write-federation-info.ts
@@ -21,6 +21,7 @@ export function writeFederationInfo(
         fedOptions.outputPath,
         locale,
         'remoteEntry.json');
+        fs.mkdirSync(path.dirname(metaDataPath),  { recursive: true });
       fs.writeFileSync(metaDataPath, JSON.stringify(federationInfo, null, 2));
     }
   }

--- a/libs/native-federation-core/src/lib/core/write-federation-info.ts
+++ b/libs/native-federation-core/src/lib/core/write-federation-info.ts
@@ -7,10 +7,21 @@ export function writeFederationInfo(
   federationInfo: FederationInfo,
   fedOptions: FederationOptions
 ) {
-  const metaDataPath = path.join(
-    fedOptions.workspaceRoot,
-    fedOptions.outputPath,
-    'remoteEntry.json'
-  );
-  fs.writeFileSync(metaDataPath, JSON.stringify(federationInfo, null, 2));
+  if (!fedOptions.locales?.length) {
+    const metaDataPath = path.join(
+      fedOptions.workspaceRoot,
+      fedOptions.outputPath,
+      'remoteEntry.json'
+    );
+    fs.writeFileSync(metaDataPath, JSON.stringify(federationInfo, null, 2));
+  } else {
+    for (const locale of fedOptions.locales) {
+      const metaDataPath = path.join(
+        fedOptions.workspaceRoot,
+        fedOptions.outputPath,
+        locale,
+        'remoteEntry.json');
+      fs.writeFileSync(metaDataPath, JSON.stringify(federationInfo, null, 2));
+    }
+  }
 }

--- a/libs/native-federation-core/src/lib/core/write-import-map.ts
+++ b/libs/native-federation-core/src/lib/core/write-import-map.ts
@@ -15,10 +15,22 @@ export function writeImportMap(
   }, {});
 
   const importMap = { imports };
-  const importMapPath = path.join(
-    fedOption.workspaceRoot,
-    fedOption.outputPath,
-    'importmap.json'
-  );
-  fs.writeFileSync(importMapPath, JSON.stringify(importMap, null, 2));
+  if (!fedOption.locales?.length) {
+    const importMapPath = path.join(
+      fedOption.workspaceRoot,
+      fedOption.outputPath,
+      'importmap.json'
+    );
+    fs.writeFileSync(importMapPath, JSON.stringify(importMap, null, 2));
+  } else {
+    for (const locale of fedOption.locales) {
+      const importMapPath = path.join(
+        fedOption.workspaceRoot,
+        fedOption.outputPath,
+        locale,
+        'importmap.json'
+      );
+      fs.writeFileSync(importMapPath, JSON.stringify(importMap, null, 2));
+    }
+  }
 }

--- a/libs/native-federation-core/src/lib/core/write-import-map.ts
+++ b/libs/native-federation-core/src/lib/core/write-import-map.ts
@@ -30,6 +30,7 @@ export function writeImportMap(
         locale,
         'importmap.json'
       );
+      fs.mkdirSync(path.dirname(importMapPath),  { recursive: true });
       fs.writeFileSync(importMapPath, JSON.stringify(importMap, null, 2));
     }
   }

--- a/libs/native-federation-core/src/lib/utils/try-copy-file-to-locales.ts
+++ b/libs/native-federation-core/src/lib/utils/try-copy-file-to-locales.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import fs from 'fs';
+import { FederationOptions } from '../core/federation-options';
+
+export function tryCopyFileToLocales(sourceFile: string, fedOptions: FederationOptions) {
+
+  if (!fedOptions.locales?.length) {
+    // in case the project has not specified localization, ignore this step
+    return;
+  }
+  const sourceBaseName = path.basename(sourceFile);
+  
+  for (const locale of fedOptions.locales) {
+    const fullOutputPath = path.join(
+        fedOptions.workspaceRoot,
+        fedOptions.outputPath,
+        locale
+    );
+    const destinationFile = path.join(fullOutputPath, sourceBaseName);
+    fs.mkdirSync(path.dirname(fullOutputPath), { recursive: true });
+    
+    if (fs.existsSync(sourceFile)) {
+        fs.copyFileSync(sourceFile, destinationFile);
+    }
+    const [sourceMapFile, destinationMapFile] = [sourceFile, destinationFile].map(f => f + '.map');
+    if (fs.existsSync(sourceMapFile)) {
+        fs.copyFileSync(sourceMapFile, destinationMapFile);
+    }
+  }
+}

--- a/libs/native-federation-core/src/lib/utils/try-copy-file-to-locales.ts
+++ b/libs/native-federation-core/src/lib/utils/try-copy-file-to-locales.ts
@@ -11,13 +11,13 @@ export function tryCopyFileToLocales(sourceFile: string, fedOptions: FederationO
   const sourceBaseName = path.basename(sourceFile);
   
   for (const locale of fedOptions.locales) {
-    const fullOutputPath = path.join(
+    const destinationFile = path.join(
         fedOptions.workspaceRoot,
         fedOptions.outputPath,
-        locale
+        locale,
+        sourceBaseName
     );
-    const destinationFile = path.join(fullOutputPath, sourceBaseName);
-    fs.mkdirSync(path.dirname(fullOutputPath), { recursive: true });
+    fs.mkdirSync(path.dirname(destinationFile), { recursive: true });
     
     if (fs.existsSync(sourceFile)) {
         fs.copyFileSync(sourceFile, destinationFile);

--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular-devkit/architect';
 
 import { Schema } from '@angular-devkit/build-angular/src/builders/browser-esbuild/schema';
+import { createI18nOptions } from '@angular-devkit/build-angular/src/utils/i18n-options';
 
 import { buildEsbuildBrowser } from '@angular-devkit/build-angular/src/builders/browser-esbuild';
 
@@ -54,6 +55,7 @@ export async function* runBuilder(
     _options,
     builder
   )) as JsonObject & Schema;
+  const i18nOptions = createI18nOptions(await context.getProjectMetadata(target.project), options.localize);
 
   const runServer = !!nfOptions.port;
   const write = !runServer;
@@ -75,6 +77,7 @@ export async function* runBuilder(
     verbose: options.verbose,
     watch: false, // options.watch,
     dev: !!nfOptions.dev,
+    locales: Array.from(i18nOptions.inlineLocales),
   };
 
   const config = await loadFederationConfig(fedOptions);

--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -55,7 +55,10 @@ export async function* runBuilder(
     _options,
     builder
   )) as JsonObject & Schema;
-  const i18nOptions = createI18nOptions(await context.getProjectMetadata(target.project), options.localize);
+  const i18nOptions = createI18nOptions(
+    await context.getProjectMetadata(target.project),
+    options.localize
+  );
 
   const runServer = !!nfOptions.port;
   const write = !runServer;

--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -3,7 +3,18 @@ import * as fs from 'fs';
 import { FederationOptions } from '@softarc/native-federation/build';
 
 export function updateIndexHtml(fedOptions: FederationOptions) {
-  const outputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
+  if (!fedOptions.locales?.length) {
+    const outputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
+    updateSingleIndexHtml(outputPath);
+  } else {
+    for (const locale of fedOptions.locales) {
+      const outputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath, locale);
+      updateSingleIndexHtml(outputPath);
+    }
+  }
+}
+
+export function updateSingleIndexHtml(outputPath: string) {
   const indexPath = path.join(outputPath, 'index.html');
   const mainName = fs
     .readdirSync(outputPath)


### PR DESCRIPTION
Hi!

This is a first attempt for basic support of i18n in native federation.

The main restriction with my implementation is that libraries can't have localizations to inline, because I did nothing with the build adapter to support it.

What I did, is that `FederationOptions` has a locales array, which is assumed to be an array of `outputPath` subfolders each with their own build output.

Each locale's folder in turn
- gets shared and mapped files copied into it
- gets federation info and import map generated into it
- indexHtml gets overwritten in it

I'm still in process of testing it, but I wanted to get your feedback asap.
I also believe I might have some extra steps to support the dev server mode, but I haven't really looked into it yet.

closes #413 