### PR TITLE
docs(native-federation): link to code

### DIFF
--- a/libs/native-federation/package.json
+++ b/libs/native-federation/package.json
@@ -10,6 +10,7 @@
     "name": "Manfred Steyer",
     "url": "http://www.angulararchitects.io"
   },
+  "homepage": "https://github.com/angular-architects/module-federation-plugin/tree/main/libs/native-federation",
   "repository": {
     "type": "git",
     "url": "https://github.com/angular-architects/module-federation-plugin"


### PR DESCRIPTION
## Problem

Native Federation is part of a Mono-Repo.
Newcomers need to distinguish between Module-Federation and Native-Federation, which can be confusing.

## Solution

It might be helpful to link the Native-Federation's directory in the _package.json_ to make it easier to find.