### PR TITLE
fix: ModifyEntryPlugin compiler options entry check.

### DIFF
--- a/libs/mf/src/utils/modify-entry-plugin.ts
+++ b/libs/mf/src/utils/modify-entry-plugin.ts
@@ -14,18 +14,20 @@ export class ModifyEntryPlugin {
       return values.length > 0 ? objFn(values) : {};
     };
     Object.keys(this.config).forEach((key) => {
-      compiler.options.entry[key] = {
-        ...cfgOrRemove(
-          (v) => ({ import: v }),
-          (c) => c.import,
-          key
-        ),
-        ...cfgOrRemove(
-          (v) => ({ dependOn: v }),
-          (c) => c.dependOn,
-          key
-        ),
-      };
+      if (compiler.options.entry[key]) {
+        compiler.options.entry[key] = {
+          ...cfgOrRemove(
+            (v) => ({ import: v }),
+            (c) => c.import,
+            key
+          ),
+          ...cfgOrRemove(
+            (v) => ({ dependOn: v }),
+            (c) => c.dependOn,
+            key
+          )
+        };
+      }
     });
   }
 }


### PR DESCRIPTION
Fix to handle missing 'styles' entry point in compiler options when eager is set to true.
https://github.com/angular-architects/module-federation-plugin/issues/417 