### PR TITLE
fix(nf): fix baseHref on build

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -61,6 +61,8 @@ export async function* runBuilder(
   const watch = !!runServer || nfOptions.watch;
 
   options.watch = watch;
+  options.baseHref = nfOptions.baseHref;
+  
   const rebuildEvents = new RebuildHubs();
 
   const adapter = createAngularBuildAdapter(options, context, rebuildEvents);


### PR DESCRIPTION
Pass baseHref to buildEsbuildBrowser options to transform index.html <base href=""> and ngsw.json generation