### PR TITLE
https option added to dev-server

### DIFF
--- a/libs/native-federation/src/builders/build/schema.d.ts
+++ b/libs/native-federation/src/builders/build/schema.d.ts
@@ -8,4 +8,7 @@ export interface NfBuilderSchema extends JsonObject {
   rebuildDelay: number;
   shell: string;
   watch: boolean;
+  https: boolean;
+  cert: string;
+  key: string;
 } // eslint-disable-line

--- a/libs/native-federation/src/builders/build/schema.json
+++ b/libs/native-federation/src/builders/build/schema.json
@@ -38,6 +38,19 @@
       "type": "string",
       "description": "Experimental",
       "default": ""
+    },
+    "https": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable SSL for local development"
+    },
+    "cert": {
+      "type": "string",
+      "description": "Path to SSL certificate"
+    },
+    "key": {
+      "type": "string",
+      "description": "Path to SSL certificate key"
     }
   }
 }

--- a/libs/native-federation/src/utils/dev-server.ts
+++ b/libs/native-federation/src/utils/dev-server.ts
@@ -24,6 +24,10 @@ export function startServer(
     single: true,
     ui: false,
     open: options.open,
+    https: options.https ? {
+      cert: options.cert,
+      key: options.key
+    } : false,
     middleware: [
       function (req, res, next) {
         const temp = req.url.startsWith('/') ? req.url.substring(1) : req.url;


### PR DESCRIPTION
I have a angular 16 application and I am using https for local development but after upgrading this application for angular 17 and native-federation 17 the parameters ssl, ssl-cert, and ssl-key stopped to work.

I looked at the source code and saw that native-federation is using browser-sync for dev-server and that it has an option to enable running with https, so I added it as an option for dev-server.