### PR TITLE
fix: convert sideEffects value to boolean

### DIFF
--- a/libs/mf/package.json
+++ b/libs/mf/package.json
@@ -13,7 +13,7 @@
   },
   "module": "src/index.js",
   "ES2015": "./src/index.js",
-  "sideEffects": "false",
+  "sideEffects": false,
   "schematics": "./collection.json",
   "builders": "./builders.json",
   "dependencies": {


### PR DESCRIPTION
According to https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free `sideEffects` field should be of boolean or array type