### PR TITLE
I18n application adapter

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -237,7 +237,11 @@ export async function* runBuilder(
     }
 
     if (write && !nfOptions.dev) {
-      updateIndexHtml(fedOptions);
+      updateIndexHtml(fedOptions); // TODO: pass it the output, and have it find all index.html-s to update
+      // TODO: at this point we can also copy remoteEntry.json from root next to each index.html
+      // TODO: remoteEntry.json-s that are copied should be transformed because they and exposed entries
+      // go to language folders, but shared files go to dist root.
+      // TODO:? import maps need to be copied and transformed like the remoteEntry-s. They're not used anywhere though.
     }
 
     if (first && runServer) {


### PR DESCRIPTION
closes #411 

## ** Consider this PR a draft for now. **
This is how i18n support could play out in my opinion:
- Shared entries/packages build just as they used to.
- Exposed entries are built by the angular application internal builder
- index.html-s are found in the build output, and each transformed
- remoteEntries are copied next to index.html-s found, and transformed for the new directory structure