### PR TITLE
fix(mf-runtime): return remote module entry for module type

### DIFF
--- a/libs/mf-runtime/src/lib/loader/dynamic-federation.ts
+++ b/libs/mf-runtime/src/lib/loader/dynamic-federation.ts
@@ -96,7 +96,7 @@ export async function loadRemoteEntry(
     return await loadRemoteScriptEntry(options.remoteEntry, options.remoteName);
   } else if (remoteEntryOrOptions.type === 'module') {
     const options = remoteEntryOrOptions;
-    await loadRemoteModuleEntry(options.remoteEntry);
+    return await loadRemoteModuleEntry(options.remoteEntry);
   }
 }
 


### PR DESCRIPTION
for remote with type==='module' return result of loadRemoteModuleEntry