### PR TITLE
Fix esbuild Adapter Results

### DIFF
--- a/libs/native-federation-esbuild/src/lib/adapter.ts
+++ b/libs/native-federation-esbuild/src/lib/adapter.ts
@@ -104,7 +104,7 @@ function writeResult(
   for (const outFile of outputFiles) {
     const fileName = path.basename(outFile.path);
     const filePath = path.join(outdir, fileName);
-    fs.writeFileSync(filePath, outFile.text);
+    fs.writeFileSync(filePath, outFile.contents);
     writtenFiles.push(filePath);
   }
 


### PR DESCRIPTION
Right now the adapter uses `.text` instead of `.contents`. The former is just the text representation, which is the same for as `.contents` for .JS files etc. but not the same for other assets such as images.