### PR TITLE
fix(nf): Inject `importmap-shim` to the `<head>` instead of the end of the `<body>`

### DIFF
--- a/libs/native-federation-runtime/src/lib/utils/add-import-map.ts
+++ b/libs/native-federation-runtime/src/lib/utils/add-import-map.ts
@@ -1,7 +1,7 @@
 import { ImportMap } from '../model/import-map';
 
 export function appendImportMap(importMap: ImportMap) {
-  document.body.appendChild(
+  document.head.appendChild(
     Object.assign(document.createElement('script'), {
       type: 'importmap-shim',
       innerHTML: JSON.stringify(importMap),


### PR DESCRIPTION
## Current Behaviour
In the `initFederation` function, the `importmap-shim` script is injected at last in the `<body>`:

<img width="409" alt="image" src="https://github.com/angular-architects/module-federation-plugin/assets/954509/5242cc17-38cc-460d-ba60-19c86a001f4e">

- Usually, it is better to have the import maps earlier because it can be used by other scripts.
- It should be also specified before the `esms-module-shims` library (which is located in the `polyfills.js`)**

> **In that use case it is not needed because it is injected afterward and [loaded dynamically by `esms-module-shims`](https://github.com/guybedford/es-module-shims?tab=readme-ov-file#dynamic-import-maps)

## Expected/Implementation

Inject the import maps in the `<head>` section instead of the `<body>`