### PR TITLE
fix(nf): Remove orphans `</scripts>` tags during `updateScriptTags`

### DIFF
--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -34,8 +34,11 @@ export function updateScriptTags(
 <script type="module-shim" src="${mainName}"></script>
 `;
 
-  indexContent = indexContent.replace(/<script src="polyfills.*?>/, '');
-  indexContent = indexContent.replace(/<script src="main.*?>/, '');
+  indexContent = indexContent.replace(
+    /<script src="polyfills.*?><\/script>/,
+    ''
+  );
+  indexContent = indexContent.replace(/<script src="main.*?><\/script>/, '');
   indexContent = indexContent.replace('</body>', `${htmlFragment}</body>`);
   return indexContent;
 }


### PR DESCRIPTION
## Current Behaviour

When transforming the `index.html`, the `updateScriptTags` functions does not remove the closed `</scripts>` tags of from the replaced scripts

![image](https://github.com/angular-architects/module-federation-plugin/assets/954509/d00eedd5-2f58-4043-8be2-350748341c6e)

## Expected/Implementation

Ensure close </scripts> tags are replaced