### PR TITLE
[TBD] feat(nf): Inject host importmap directly into the index.html instead of processing it at runtime

### DIFF
--- a/libs/native-federation-runtime/src/lib/utils/path-utils.ts
+++ b/libs/native-federation-runtime/src/lib/utils/path-utils.ts
@@ -4,6 +4,11 @@ export function getDirectory(url: string) {
   return parts.join('/');
 }
 
+export function getFile(url: string) {
+  const parts = url.split('/');
+  return parts.pop();
+}
+
 export function joinPaths(path1: string, path2: string): string {
   while (path1.endsWith('/')) {
     path1 = path1.substring(0, path1.length - 1);

--- a/libs/native-federation-runtime/tsconfig.lib.json
+++ b/libs/native-federation-runtime/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": [],
+    "types": ["es-module-shims"],
     "target": "ES2022",
     "useDefineForClassFields": false
   },

--- a/libs/native-federation-runtime/tsconfig.lib.prod.json
+++ b/libs/native-federation-runtime/tsconfig.lib.prod.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declarationMap": false,
     "target": "ES2022",
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "types": ["es-module-shims"]
   },
   "angularCompilerOptions": {
     "compilationMode": "partial"

--- a/libs/native-federation-runtime/tsconfig.spec.json
+++ b/libs/native-federation-runtime/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "es-module-shims"]
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]

--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -51,5 +51,14 @@ export function updateScriptTags(
   );
   indexContent = indexContent.replace(/<script src="main.*?><\/script>/, '');
   indexContent = indexContent.replace('</body>', `${htmlFragment}</body>`);
+
+  // add link to importmap.json
+  const scriptTagImportMap =
+    '<script type="importmap-shim" src="./importmap.json"></script>';
+  indexContent = indexContent.replace(
+    '</head>',
+    `${scriptTagImportMap}\n</head>`
+  );
+
   return indexContent;
 }


### PR DESCRIPTION
Split of https://github.com/angular-architects/module-federation-plugin/pull/513

### Description

At runtime, the `remoteEntry.json` of the host is loaded, processed and converted to an importmap.
However, because the processing is done by the host, it is possible to directly include it in the `index.html` to reduce runtime execution.

To ensure the externals are still treated correctly, we compare the filename which are containing the version of the shared.