### PR TITLE
[DRAFT] chore(nf): Use Nx Additional entry points

### DIFF
--- a/libs/native-federation-core/build.ts
+++ b/libs/native-federation-core/build.ts
@@ -1,1 +1,0 @@
-export * from './src/build';

--- a/libs/native-federation-core/project.json
+++ b/libs/native-federation-core/project.json
@@ -10,6 +10,11 @@
       "options": {
         "outputPath": "dist/libs/native-federation-core",
         "main": "libs/native-federation-core/src/index.ts",
+        "additionalEntryPoints": [
+          "libs/native-federation-core/src/build.ts",
+          "libs/native-federation-core/src/config.ts"
+        ],
+        "generateExportsField": true,
         "tsConfig": "libs/native-federation-core/tsconfig.lib.json",
         "assets": [
           "libs/native-federation-core/*.md",

--- a/libs/native-federation/config.ts
+++ b/libs/native-federation/config.ts
@@ -1,1 +1,0 @@
-export * from './src/config';

--- a/libs/native-federation/project.json
+++ b/libs/native-federation/project.json
@@ -10,6 +10,8 @@
       "options": {
         "outputPath": "dist/libs/native-federation",
         "main": "libs/native-federation/src/index.ts",
+        "additionalEntryPoints": ["libs/native-federation/src/config.ts"],
+        "generateExportsField": true,
         "tsConfig": "libs/native-federation/tsconfig.lib.json",
         "assets": [
           "libs/native-federation/*.md",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,6 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@angular-architects/build_angular": ["libs/build-angular/src/index.ts"],
       "@angular-architects/module-federation": ["libs/mf/src/index.ts"],
       "@angular-architects/module-federation-runtime": [
         "libs/mf-runtime/src/index.ts"
@@ -26,6 +25,9 @@
       ],
       "@angular-architects/native-federation": [
         "libs/native-federation/src/index.ts"
+      ],
+      "@angular-architects/native-federation/config": [
+        "libs/native-federation/src/config.ts"
       ],
       "@angular-architects/playground-lib": [
         "libs/playground-lib/src/index.ts"
@@ -40,7 +42,7 @@
         "libs/native-federation-runtime/src/index.ts"
       ],
       "@softarc/native-federation/build": [
-        "libs/native-federation-core/build.ts"
+        "libs/native-federation-core/src/build.ts"
       ]
     }
   },


### PR DESCRIPTION
Use [Nx Addtionational entry points](https://nx.dev/recipes/tips-n-tricks/define-secondary-entrypoints) instead of creating manually a file `config.ts` or `build.ts` to expose different features of a library

**BLOCKING: It does not compile but no idea why...some relation with `@module-federation/vite`**