### PR TITLE
feat(nf): use native federation with ng builder instead of adapter

### DIFF
--- a/libs/native-federation/src/builders/serve/builder.ts
+++ b/libs/native-federation/src/builders/serve/builder.ts
@@ -1,0 +1,113 @@
+import { ExecutorContext, parseTargetString, readTargetOptions } from '@nx/devkit';
+import type { Plugin } from 'esbuild';
+
+import { executeDevServer } from '@angular/build/src/builders/dev-server/';
+import { Schema } from '@angular/build/src/builders/dev-server/schema';
+import { eachValueFrom } from '@nx/devkit/src/utils/rxjs-for-await';
+import { FederationInfo } from '@softarc/native-federation-runtime';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import { lookup } from 'mrmime';
+import { extname, join } from 'path';
+import { Connect } from 'vite';
+import { entryPointsPlugin } from '../../utils/entry-points-plugin';
+import { externalsPlugin } from '../../utils/externals-plugin';
+import { initFederationBuild } from '../../utils/init-federation-build';
+import { createSharedMappingsPlugin } from '../../utils/shared-mappings-plugin';
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
+import { transformIndexHtml } from '../../utils/updateIndexHtml';
+
+
+export async function* serveNativeFederation(options: Schema, context: BuilderContext) {
+  options.watch = true;
+  options.liveReload = true;
+
+  const buildTarget = parseTargetString(options.buildTarget, context.projectGraph)
+  const buildOptions = readTargetOptions(buildTarget, context);
+
+  const outdir = typeof buildOptions.outputPath === 'string' ? buildOptions.outputPath : buildOptions.outputPath.base;
+  const browserOutDir = outdir + '/browser';
+
+  if (existsSync(browserOutDir)) {
+    rmSync(browserOutDir, { recursive: true });
+  }
+
+  if (!existsSync(browserOutDir)) {
+    mkdirSync(browserOutDir, { recursive: true });
+  }
+
+  const fedData = await initFederationBuild(context.workspaceRoot, browserOutDir, buildOptions.tsConfig);
+
+  const plugins: Plugin[] = [
+    entryPointsPlugin(fedData.entries),
+    createSharedMappingsPlugin(fedData.sharedMappings),
+    externalsPlugin(fedData.externals),
+  ];
+
+  const middleware: Connect.NextHandleFunction[] = [
+    returnRemoteEntryFromFs(context.workspaceRoot, browserOutDir),
+  ];
+
+  const ngDevServer = executeDevServer(
+    options,
+    context,
+    { indexHtml: transformIndexHtml() },
+    {
+      middleware,
+      buildPlugins: plugins,
+      builderSelector: () => '@angular-devkit/build-angular:application',
+    }
+  );
+
+  return yield* eachValueFrom(ngDevServer);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default createBuilder(serveNativeFederation) as any;
+
+function returnRemoteEntryFromFs(workspaceRoot: string, browserOutDir: string): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const fileName = join(
+      workspaceRoot,
+      browserOutDir,
+      req.url
+    );
+    const exists = existsSync(fileName);
+  
+    if (req.url === '/remoteEntry.json' && exists) {
+      const mimeType = lookup(extname(fileName)) || 'text/javascript';
+      const rawBody = readFileSync(fileName, 'utf-8');
+      const body = addDebugInformation(req.url, rawBody);
+      res.writeHead(200, {
+        'Content-Type': mimeType,
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      res.end(body);
+    } else {
+      next();
+    }
+  }
+}
+
+function addDebugInformation(fileName: string, rawBody: string): string {
+  const remoteEntry = JSON.parse(rawBody) as FederationInfo;
+  const shared = remoteEntry.shared;
+
+  if (!shared) {
+    return rawBody;
+  }
+
+  const sharedForVite = shared.map((s) => ({
+    ...s,
+    packageName: `/@id/${s.packageName}`,
+  }));
+
+  remoteEntry.shared = [...shared, ...sharedForVite];
+
+  return JSON.stringify(remoteEntry, null, 2);
+}

--- a/libs/native-federation/src/utils/entry-points-plugin.ts
+++ b/libs/native-federation/src/utils/entry-points-plugin.ts
@@ -1,0 +1,18 @@
+import type { Plugin, PluginBuild } from "esbuild";
+
+/**
+ * add entries to bundler's entryPoints
+ * 
+ * @param entries deps obj, which builder should handle as independent files
+ */
+export const entryPointsPlugin = (entries: Record<string, string>): Plugin => {
+    return {
+        name: 'entry-points',
+        setup: (build: PluginBuild) => {
+          build.initialOptions.entryPoints = {
+            ...build.initialOptions.entryPoints,
+            ...entries,
+          }
+        }
+    }
+}

--- a/libs/native-federation/src/utils/externals-plugin.ts
+++ b/libs/native-federation/src/utils/externals-plugin.ts
@@ -1,0 +1,14 @@
+import type { Plugin, PluginBuild } from "esbuild";
+
+export const externalsPlugin = (externals: string[]): Plugin => {
+    return {
+        name: 'externals',
+        setup(build: PluginBuild) {
+          if (build.initialOptions.platform !== 'node') {
+            build.initialOptions.external = externals.filter(
+              (e) => e !== 'tslib'
+            );
+          }
+        },
+      }
+}

--- a/libs/native-federation/src/utils/init-federation-build.ts
+++ b/libs/native-federation/src/utils/init-federation-build.ts
@@ -1,0 +1,82 @@
+import { BuildAdapter, BuildHelperParams, FederationOptions, MappedPath, federationBuilder } from '@softarc/native-federation/build';
+import { dirname, join } from "path";
+
+function infereConfigPath(tsConfig: string): string {
+  const relProjectPath = dirname(tsConfig);
+  const relConfigPath = join(relProjectPath, 'federation.config.js');
+
+  return relConfigPath;
+}
+/**
+ * @param entries external deps obj, adapter should fill
+ * @returns file names array. Native Federation would think they are already built and fill remoteEntry.json with their data
+ */
+const getMockAdapter = (entries: Record<string, string>): BuildAdapter => {
+  return ({entryPoints}) => {
+    entryPoints.forEach(entry => {
+      // angular builder manage ext itself
+      // if not do this, output file would be soms line foo-bar.js.js
+      const name = entry.outName.replace('.js', '');
+
+      if (!entries[name]) {
+        entries[name] = entry.fileName;
+      }
+    });
+  
+    const res = entryPoints.map(entry => ({fileName: entry.outName}));
+  
+    return Promise.resolve(res);
+  }
+}
+
+interface InitFederationBuildData {
+  entries: Record<string, string>;
+  sharedMappings: MappedPath[];
+  externals: string[]
+}
+
+/**
+ * initiating native federation for build
+ * 
+ * 1. bundler should think {@link InitFederationBuildData.externals} are external deps and not include them into bundle
+ * 2. bundler should build every entry from {@link InitFederationBuildData.entries} as independent file
+ * 
+ * @param root root dir (like contest.workspaceRoot)
+ * @param outputPath path to store remoteEntry.json (soms like dist/<project name>/browser)
+ * @param tsConfPath path to application's tsconfig
+ * @returns all the federation data {@link InitFederationBuildData}
+ */
+export const initFederationBuild = async (root: string, outputPath: string, tsConfPath): Promise<InitFederationBuildData> => {
+  // entries obj, it'll be filled by adapter
+  const fedEntries: Record<string, string> = {};
+  const mockAdapter: BuildAdapter = getMockAdapter(fedEntries);
+
+  const fedOptions: FederationOptions = {
+    workspaceRoot: root,
+    outputPath: outputPath,
+    federationConfig: infereConfigPath(tsConfPath),
+    tsConfig: tsConfPath,
+    verbose: false,
+    watch: false,
+    dev: true,
+  };
+
+  const params: BuildHelperParams = {
+    options: fedOptions,
+    adapter: mockAdapter,
+  }
+  
+  
+  await federationBuilder.init(params);
+
+  // after this line federationBuilder will call mockAdapter and fill remoteEntry.json with it's result
+  // 1. when fired, mockAdapter will fill fedEntries with file names and their pathes, builder should build
+  // 2. remoteEntry.json will store deps list with files names. Each file should contain it's dependency content. It's important for builder not to rename those files
+  await federationBuilder.build();
+
+  return {
+    entries: fedEntries,
+    sharedMappings: federationBuilder.config.sharedMappings,
+    externals: federationBuilder.externals,
+  };
+}

--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -3,10 +3,7 @@ import * as fs from 'fs';
 import { FederationOptions } from '@softarc/native-federation/build';
 import { NfBuilderSchema } from '../builders/build/schema';
 
-export function updateIndexHtml(
-  fedOptions: FederationOptions,
-  nfOptions: NfBuilderSchema
-) {
+export function updateIndexHtml(fedOptions: FederationOptions) {
   const outputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
   const indexPath = path.join(outputPath, 'index.html');
   const mainName = fs
@@ -22,7 +19,6 @@ export function updateIndexHtml(
     indexContent,
     mainName,
     polyfillsName,
-    nfOptions
   );
   fs.writeFileSync(indexPath, indexContent, 'utf-8');
 }
@@ -31,11 +27,9 @@ export function updateScriptTags(
   indexContent: string,
   mainName: string,
   polyfillsName: string,
-  nfOptions: NfBuilderSchema
 ) {
   const esmsOptions = {
     shimMode: true,
-    ...nfOptions.esmsInitOptions,
   };
 
   const htmlFragment = `
@@ -52,4 +46,11 @@ export function updateScriptTags(
   indexContent = indexContent.replace(/<script src="main.*?><\/script>/, '');
   indexContent = indexContent.replace('</body>', `${htmlFragment}</body>`);
   return indexContent;
+}
+
+export function transformIndexHtml(): (content: string) => Promise<string> {
+  return (content: string): Promise<string> =>
+    Promise.resolve(
+      updateScriptTags(content, 'main.js', 'polyfills.js')
+    );
 }


### PR DESCRIPTION
As long as native federation is a great idea i see great performance and architectural issue using literally 2 builders at once (app builder and adapter)

For example my app code:
1. would build at 10 seconds
2. I would see all the build artefacts, loaders etc
3. rebuild would call page reload when serve

All the federation artefacts (node packages, exposes, non-buildable libs etc) would built in other proccess:
1. in unknown time (we can put a timestamp on that, but that is not the point)
2. with unknown artefacts
3. with no loaders
4. rebuild when serve would not call page reload 
5. rebuild when serve will take incredible amount of time compared to main build 
    - thats because of initiating esbuild on each change, which took up to 10-15 seconds on a big projects


I spent some amount of time thinking if i could do something about it and this PR is the result, i tried to leave comment on each potentially non-obvious line

Main idea is:

1. use NF to calc all the federation artefacts and create mappings (remoteEntry.json)
2. set ng builder to build both the app code (excluding NF artefacts) and all the calculated files
3. handle runtime pretty much same as it was earlier except NF files when serve (dev server can handle them like all the others now)

If you try it out you'll see:
1. build
    2. pretty much the same speed
    3. correct files and artefacts in console
2. serve
    3. same as build on start
    4. faster rebuilds
    5. transparent data in console
    6. nice page reloading on edit any artefacts

One more thing - i understand that it is not a prod-ready code. Right now it's more about to validate if this idea has right to live, or is it failure even on PoC stage)

It would be my personal great achievement if this PR would be accepted. Appreciate any comments, thoughts, questions or additions, thank you in advance