### PR TITLE
small simplification

### DIFF
--- a/libs/native-federation-runtime/src/lib/init-federation.ts
+++ b/libs/native-federation-runtime/src/lib/init-federation.ts
@@ -34,14 +34,13 @@ async function loadManifest(remotes: string): Promise<Record<string, string>> {
 async function processRemoteInfos(
   remotes: Record<string, string>
 ): Promise<ImportMap> {
-  const processRemoteInfoPromises = Object.keys(remotes).map(
-    async (remoteName) => {
+  const processRemoteInfoPromises = Object.entries(remotes).map(
+    async ([ name, url ]) => {
       try {
-        const url = remotes[remoteName];
-        return await processRemoteInfo(url, remoteName);
+        return await processRemoteInfo(url, name);
       } catch (e) {
         console.error(
-          `Error loading remote entry for ${remoteName} from file ${remotes[remoteName]}`
+          `Error loading remote entry for ${name} from file ${url}`
         );
         return null;
       }


### PR DESCRIPTION
use Object.entries instead of Object.keys since both the key and value are used