### PR TITLE
docs: add template for GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report a bug or regression in functionality
+
+body:
+  - type: dropdown
+    id: affected-packages
+    attributes:
+      label: With what library do you have an issue?
+      options:
+        - native-federation
+        - module-federation
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction of the bug/regression with instructions
+      description: If on Native Federation, use our [Stackblitz template](https://stackblitz.com/github/rainerhahnekamp/native-federation-stackblitz?file=projects%2Fhost%2Fsrc%2Fapp%2Fapp.routes.ts) to reproduce the issue
+      placeholder: If the bug/regression does not include a reproduction via StackBlitz or GitHub repo, your issue may be closed without resolution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what the expected behavior would be.
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Versions of Native/Module Federation, Angular, Node, Browser, and operating system
+      placeholder: |
+        Native/Module Federation:
+        Angular:
+        Node:
+        Browser:
+        Operating system(s):
+    validations:
+      required: true
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+
+  - type: checkboxes
+    id: assistance
+    attributes:
+      label: I would be willing to submit a PR to fix this issue
+      description: Assistance is provided if you need help submitting a pull request
+      options:
+        - label: 'Yes'
+        - label: 'No'

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Submit a Request For Consideration
+
+body:
+  - type: dropdown
+    id: affected-packages
+    attributes:
+      label: For which library do you have a feature request?
+      options:
+        - native-federation
+        - module-federation
+        - other
+      multiple: true
+    validations:
+      required: true
+
+  - type: textarea
+    id: information
+    attributes:
+      label: Information
+      description: What feature would you like to see added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe any alternatives/workarounds you're currently using
+
+  - type: checkboxes
+    id: assistance
+    attributes:
+      label: I would be willing to submit a PR to fix this issue
+      description: Assistance is provided if you need help submitting a pull request
+      options:
+        - label: 'Yes'
+        - label: 'No'

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,23 @@
+name: Question / Help
+description: Ask a question or request help
+
+body:
+  - type: dropdown
+    id: affected-packages
+    attributes:
+      label: For which library do you need help?
+      options:
+        - native-federation
+        - module-federation
+        - other
+      multiple: true
+    validations:
+      required: true
+
+  - type: textarea
+    id: information
+    attributes:
+      label: Question
+      description: What do you need help with?
+    validations:
+      required: true


### PR DESCRIPTION
Issues can be created for three categories:
- Bug Reports
- Feature Requestion
- General Question

The template for the bug reports includes also a
link to the Stackblitz example on
https://stackblitz.com/github/rainerhahnekamp/native-federation-stackblitz?file=projects%2Fhost%2Fsrc%2Fapp%2Fapp.routes.ts