### PR TITLE
fix(nf): correct the index file path for SSR builds in the updateIndexHtml util

### DIFF
--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -8,7 +8,7 @@ export function updateIndexHtml(
   nfOptions: NfBuilderSchema
 ) {
   const outputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
-  const indexPath = path.join(outputPath, 'index.html');
+  const indexPath = path.join(outputPath, nfOptions.ssr ? 'index.csr.html' : 'index.html');
   const mainName = fs
     .readdirSync(outputPath)
     .find((f) => f.startsWith('main') && f.endsWith('.js'));


### PR DESCRIPTION
Angular CLI generates an [index.csr.html](https://github.com/angular/angular-cli/blob/main/packages/angular/build/src/builders/application/options.ts#L333) file for SSR builds, causing the updateIndexHtml function to fail since it looks for an ‘index.html’ file. To ensure the function works correctly, a check for the SSR option needs to be added to the utility.