### PR TITLE
docs/typos-in-faqs

### DIFF
--- a/libs/native-federation/README.md
+++ b/libs/native-federation/README.md
@@ -348,9 +348,9 @@ For this, there are several reasons:
 
 The good message is, that the official Angular Package Format defines the usage of ECMA Script Modules (ESM) for years. This is the future-proof standard, Native Federation is built upon and all npm packages created with the Angular CLI follow. If you use older CommonJS-based packages, Native Federation automatically converts them to ESM. Depending on the package, this might change some details. Here, you find some [information for dealing with CommonJS packages](https://shorturl.at/jmzH0).
 
-## How to Deal with Transitive Dependencies?
+### How to Deal with Transitive Dependencies?
 
-Since version 18@latest, also transitive dependencies can be shared. For instance, `primeng` uses a lib `@primeuix/styled` for theming. The latter one is now shared too if `primeng` is. This prevents possible challanges but also results in more bundles. 
+Since version >=18.2.7, transitive dependencies can also be shared. For instance, `primeng` uses a lib `@primeuix/styled` for theming. The latter one is now shared too if `primeng` is. This prevents possible challenges but also results in more bundles. 
 
 To activate sharing transient dependencies, set the new `transient` flag provided by `share` and `shareAll` to `true`:
 
@@ -370,9 +370,9 @@ module.exports = withNativeFederation({
 
 The `skip` list will also be used for filtering transient dependencies. Hence, you can combine it with `shareAll` and `transient: true`.
 
-## How to Manually Define a Package's Entry Point?
+### How to Manually Define a Package's Entry Point?
 
-Usually, Native Federation automatically detects entry points into shared packages. If the packages neither align with the official standard nor with typical conventions beyond these standards, you can also directly provide the entry point:
+Usually, Native Federation automatically detects entry points in shared packages. If the packages neither align with the official standard nor with typical conventions beyond these standards, you can also directly provide the entry point:
 
 ```js
 module.exports = withNativeFederation({


### PR DESCRIPTION
Fixes some minor typos in the latest additions to the FAQ