### PR TITLE
fix(nf): backslashes not converted to slashes in sub dependency paths

### DIFF
--- a/libs/native-federation-core/src/lib/config/with-native-federation.ts
+++ b/libs/native-federation-core/src/lib/config/with-native-federation.ts
@@ -46,7 +46,7 @@ function normalizeShared(
     result = Object.keys(shared).reduce(
       (acc, cur) => ({
         ...acc,
-        [cur]: {
+        [cur.replace(/\\/g, '/')]: {
           requiredVersion: shared[cur].requiredVersion ?? 'auto',
           singleton: shared[cur].singleton ?? false,
           strictVersion: shared[cur].strictVersion ?? false,


### PR DESCRIPTION
When I was trying to use PrimeNG with Native Federation. I got an error like:

`Unable to resolve specifier '@primeuix/utils/object' imported from .......`

`@primeuix` is a sub dependency installed by `primeng`. After looking at the array of discovered sub dependencies I discovered that they all looked like:

`@primeuix\\utils\\........`

It seems that all sub dependencies which Native Federation discovers by itself while building look like this on Windows. After applying this little fix, everything looks to be fine. If this is the correct fix, please approve/merge it asap, because this is a blocker for us to use PrimeNG in a Native Federation environment. Thanks!