### PR TITLE
chore(nx): Upgrade semver to avoid CVE-2022-25883

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "rollup": "^3.27.0",
         "rollup-plugin-esbuild": "^5.0.0",
         "rollup-plugin-node-externals": "^6.1.1",
-        "semver": "^7.3.5",
+        "semver": "7.7.1",
         "ts-jest": "29.1.1",
         "ts-node": "10.9.1",
         "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "rollup": "^3.27.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-node-externals": "^6.1.1",
-    "semver": "^7.3.5",
+    "semver": "7.7.1",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",


### PR DESCRIPTION
Closes #344 