### PR TITLE
fix(index-file): fixed the double quote issue

### DIFF
--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -57,14 +57,14 @@ export function updateScriptTags(
 `;
 
   indexContent = indexContent.replace(
-    /<script src="(.*?polyfills.*?)><\/script>/,
+    /<script src="(.*?polyfills.*?)".*?><\/script>/,
     '<script type="module" src="$1"></script>'
   );
   indexContent = indexContent.replace(
-    /<script src="(.*?main.*?)><\/script>/,
+    /<script src="(.*?main.*?)".*?><\/script>/,
     '<script type="module-shim" src="$1"></script>'
   );
 
-  indexContent = indexContent.replace('<body>', `<body>${htmlFragment}`);
+  indexContent = indexContent.replace(/(<body.*?>)/, `$1\n\t\t${htmlFragment}`);
   return indexContent;
 }


### PR DESCRIPTION
- fix for issue #836
- also fixed the body tag replacement string when attaching a class to body f.ex. <body class="mat-typography"> it would not find it and add the esms-options

