### PR TITLE
fix(i18n): support both string and object forms of i18n.sourceLocale

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -155,10 +155,15 @@ export async function* runBuilder(
 
   const localeFilter = getLocaleFilter(options, runServer);
 
+  const sourceLocaleSegment =
+    typeof i18n?.sourceLocale === 'string'
+      ? i18n.sourceLocale
+      : i18n?.sourceLocale?.subPath || i18n?.sourceLocale?.code || '';
+
   const browserOutputPath = path.join(
     outputOptions.base,
     outputOptions.browser,
-    options.localize ? i18n?.sourceLocale || '' : ''
+    options.localize ? sourceLocaleSegment : ''
   );
 
   const differentDevServerOutputPath =

--- a/libs/native-federation/src/utils/i18n.ts
+++ b/libs/native-federation/src/utils/i18n.ts
@@ -10,8 +10,14 @@ export type WorkspaceConfig = {
 };
 
 export type I18nConfig = {
-  sourceLocale: string;
+  sourceLocale: string | SourceLocaleObject;
   locales: Record<string, string>;
+};
+
+export type SourceLocaleObject = {
+  code: string;
+  baseHref?: string;
+  subPath?: string;
 };
 
 export async function getI18nConfig(
@@ -52,7 +58,10 @@ export async function translateFederationArtefacts(
 
   const targetLocales = locales.join(' ');
 
-  const sourceLocale = i18n.sourceLocale;
+  const sourceLocale =
+    typeof i18n.sourceLocale === 'string'
+      ? i18n.sourceLocale
+      : i18n.sourceLocale.code;
 
   const translationOutPath = path.join(outputPath, 'browser', '{{LOCALE}}');
 


### PR DESCRIPTION
The original implementation assumed `sourceLocale` was always a `string`. However, Angular allows it to be either([see schema](https://github.com/angular/angular-cli/blob/34ed2135fc0f3b68332df67bcb9b4824fd718b60/packages/angular/cli/lib/config/workspace-schema.json#L263)):

- A simple string (e.g., "en-US")
- An object with properties like `code`, `subPath`, and `baseHref`

When an object was used, the resulting output path included `[object Object]`, causing incorrect output paths or build failures.

This fix ensures compatibility with the full range of valid `sourceLocale` definitions