### PR TITLE
fix(nf): Reference optimization flag to determine correct build when running locally

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -175,7 +175,7 @@ export async function* runBuilder(
     tsConfig: options.tsConfig,
     verbose: options.verbose,
     watch: false, // options.watch,
-    dev: !!nfOptions.dev,
+    dev: typeof options.optimization == "boolean" ? !options.optimization : !!nfOptions.dev,
     entryPoint,
     buildNotifications: nfOptions.buildNotifications,
   };


### PR DESCRIPTION
Respect what optimization says when it's a boolean to determine whether a dev build is used