### PR TITLE
chore: improve code error message for missing Angular project in angu…

### DIFF
--- a/libs/mf/src/schematics/init-rspack/schematic.ts
+++ b/libs/mf/src/schematics/init-rspack/schematic.ts
@@ -140,7 +140,7 @@ function normalizeOptions(tree, options: MfSchematicSchema): NormalizedOptions {
   const projectConfig = workspace.projects[projectName];
 
   if (!projectConfig) {
-    throw new Error(`Project ${projectName} not found!`);
+    throw new Error(`Project ${projectName} not found in angular.json.`);
   }
 
   const projectRoot: string = projectConfig.root?.replace(/\\/g, '/');

--- a/libs/mf/src/schematics/init-webpack/schematic.ts
+++ b/libs/mf/src/schematics/init-webpack/schematic.ts
@@ -213,7 +213,7 @@ export default function config(options: MfSchematicSchema): Rule {
     const projectConfig = workspace.projects[projectName];
 
     if (!projectConfig) {
-      throw new Error(`Project ${projectName} not found!`);
+      throw new Error(`Project ${projectName} not found in angular.json.`);
     }
 
     const projectRoot: string = projectConfig.root?.replace(/\\/g, '/');

--- a/libs/native-federation/src/schematics/appbuilder/schematic.ts
+++ b/libs/native-federation/src/schematics/appbuilder/schematic.ts
@@ -104,7 +104,7 @@ function normalizeOptions(
   const projectConfig = workspace.projects[projectName];
 
   if (!projectConfig) {
-    throw new Error(`Project ${projectName} not found!`);
+    throw new Error(`Project ${projectName} not found in angular.json.`);
   }
 
   const projectRoot: string = projectConfig.root?.replace(/\\/g, '/');

--- a/libs/native-federation/src/schematics/init/schematic.ts
+++ b/libs/native-federation/src/schematics/init/schematic.ts
@@ -348,7 +348,7 @@ function normalizeOptions(
   const projectConfig = workspace.projects[projectName];
 
   if (!projectConfig) {
-    throw new Error(`Project ${projectName} not found!`);
+    throw new Error(`Project ${projectName} not found in angular.json.`);
   }
 
   const projectRoot: string = projectConfig.root?.replace(/\\/g, '/');

--- a/libs/native-federation/src/schematics/remove/schematic.ts
+++ b/libs/native-federation/src/schematics/remove/schematic.ts
@@ -105,7 +105,7 @@ function normalizeOptions(
   const projectConfig = workspace.projects[projectName];
 
   if (!projectConfig) {
-    throw new Error(`Project ${projectName} not found!`);
+    throw new Error(`Project ${projectName} not found in angular.json.`);
   }
 
   const projectRoot: string = projectConfig.root?.replace(/\\/g, '/');


### PR DESCRIPTION
I have updated all instances of:

```typescript
throw new Error(`Project ${projectName} not found!`);
```
to
```typescript
throw new Error(`Project ${projectName} not found in angular.json.`);
```

because my team and I (due to our own oversight in not reading the documentation) had difficulty, as we thought we needed to use the property name in webconfig instead of the project name.
So, I’m suggesting this change to make the error message more descriptive, which could save time for others in the future (if you agree).