### PR TITLE
fix: passes through sourceMap options from esbuild options

### DIFF
--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -278,7 +278,7 @@ async function runEsbuild(
     external,
     logLevel,
     bundle: true,
-    sourcemap: dev,
+    sourcemap: sourcemapOptions.scripts,
     minify: !dev,
     supported: {
       'async-await': false,


### PR DESCRIPTION
This PR fixes #814 by passing through the existing `sourceMap` option when invoking `esbuild` inside the Angular build adapter.  The plugin is already normalizing the sourcemap options, I chose to pass `sourcemapOptions.scripts` as the flag for whether to enable source maps.

I considered an alternative implementation of adding a new builder schema option to explicitly define sourceMaps, but I think that would be confusing since it wraps/adapts the existing ESBuild options.