### PR TITLE
feat(mf-tools): enhance connectRouter to support baseHref for URL navigation

### DIFF
--- a/libs/mf-tools/src/lib/web-components/bootstrap-utils.ts
+++ b/libs/mf-tools/src/lib/web-components/bootstrap-utils.ts
@@ -7,9 +7,10 @@ import {
   PlatformRef,
   Type,
   Version,
+  VERSION,
 } from '@angular/core';
 import { platformBrowser } from '@angular/platform-browser';
-import { VERSION } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
 import {
   getGlobalStateSlice,
   setGlobalStateSlice,
@@ -211,6 +212,7 @@ function shareShellZone(injector: Injector) {
 
 function connectMicroFrontendRouter(injector: Injector) {
   const router = injector.get(Router);
+  const baseHref = injector.get(APP_BASE_HREF, '');
   const useHash = location.href.includes('#');
 
   if (!router) {
@@ -218,5 +220,5 @@ function connectMicroFrontendRouter(injector: Injector) {
     return;
   }
 
-  connectRouter(router, useHash);
+  connectRouter(router, useHash, baseHref);
 }

--- a/libs/mf-tools/src/lib/web-components/router-utils.ts
+++ b/libs/mf-tools/src/lib/web-components/router-utils.ts
@@ -20,10 +20,17 @@ export function endsWith(prefix: string): UrlMatcher {
   };
 }
 
-export function connectRouter(router: Router, useHash = false): void {
+export function connectRouter(
+  router: Router,
+  useHash = false,
+  baseHref?: string
+): void {
   let url: string;
   if (!useHash) {
     url = `${location.pathname.substring(1)}${location.search}`;
+    if (baseHref && url.startsWith(baseHref)) {
+      url = url.replace(baseHref, '');
+    }
     router.navigateByUrl(url);
     window.addEventListener('popstate', () => {
       router.navigateByUrl(url);


### PR DESCRIPTION
This pull request updates module federation tools, the micro frontend router integration to improve support for custom base hrefs in Angular applications. The main changes ensure that the router correctly handles navigation when a base href is set, which is important for apps deployed under sub-paths.

Routing improvements:

* Added retrieval of `APP_BASE_HREF` from the Angular injector and passed it to the router connection logic in `bootstrap-utils.ts`, enabling dynamic base href support. [[1]](diffhunk://#diff-1e595e9246ffa228506c1a223962f411fb69bbe5a3305fe2ef8c521837bf14aaR10-R13) [[2]](diffhunk://#diff-1e595e9246ffa228506c1a223962f411fb69bbe5a3305fe2ef8c521837bf14aaR215-R223)
* Updated the `connectRouter` function in `router-utils.ts` to accept a `baseHref` parameter and remove the base href from the beginning of navigation URL if present, ensuring correct routing behavior for apps with a non-root base path.