### PR TITLE
fix(nf): Bug in remoteUnusedDeps where shared-mappings could never be matched

### DIFF
--- a/libs/native-federation-core/src/lib/core/remove-unused-deps.ts
+++ b/libs/native-federation-core/src/lib/core/remove-unused-deps.ts
@@ -73,8 +73,8 @@ function findUsedDeps(
     }
 
     const fullFileName = path.join(workspaceRoot, fileName);
-    const mappings = config.sharedMappings.filter(
-      (sm) => sm.path === fullFileName
+    const mappings = config.sharedMappings.filter((sm) =>
+      fullFileName.startsWith(sm.path)
     );
 
     for (const mapping of mappings) {


### PR DESCRIPTION
Closes #927 

The issue was introduced in 20.0.3 along with the removeUnusedDeps feature. In current behavior the import is matched  against the path of the sharedMapping using `===` however:

```typescript
const fullFileName = "....auke/Projects/nf-debug/ng20/dist/shared/index.d.ts";

const config.sharedMappings = [
  {
    key: '@shared',
    path: '....auke/Projects/nf-debug/ng20/dist/shared'
  }
]
```

Since the mapping maps to a folder, the file will never be matched, hence the sharedMapping will be marked as "unused" and thus removed. 

The fix changes this to a "startsWith", essentially checking if the sharedMapping is from the mapped folder. 
