### PR TITLE
Fix SSE url check never reaching setupSSEConnection.

### DIFF
--- a/libs/native-federation/src/builders/build/federation-build-notifier.ts
+++ b/libs/native-federation/src/builders/build/federation-build-notifier.ts
@@ -64,12 +64,10 @@ export class FederationBuildNotifier {
     }
 
     return (req: IncomingMessage, res: ServerResponse, next: NextFunction) => {
-      const url = removeBaseHref(req);
-
+      const url = this.endpoint.startsWith('/') ? '/' + removeBaseHref(req) : removeBaseHref(req);
       if (url !== this.endpoint) {
         return next();
       }
-
       this._setupSSEConnection(req, res);
     };
   }


### PR DESCRIPTION
There is an issue with the SSE-connection logic. 
A check exists `if (url !== this.endpoint) { return next() }` where `this.endpoint` default starts with a `/`, example `/@angular-architects/native-federation:build-notifications` and the incoming `url` variable gets stripped to being without a leading `/`. Therefore, it always goes into the above if-clause, resulting in `setupSSEConnection` being unreachable, ultimately never setting up an SSE build-notification connection properly.

This fix checks if `this.endpoint` has a leading `/`, if so it adds a leading `/` onto the `url` variable for proper comparison.