### PR TITLE
fix(nf): Bug where application could not be built in devmode

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -244,7 +244,7 @@ export async function* runBuilder(
     options.externalDependencies = externals;
   }
 
-  const isLocalDevelopment = runServer || nfOptions.dev;
+  const isLocalDevelopment = runServer && nfOptions.dev;
 
   // Initialize SSE reloader only for local development
   if (isLocalDevelopment && nfOptions.buildNotifications?.enable) {


### PR DESCRIPTION
Closes #907.

When building the application in devmode, the user was greeted with an error saying that split doesnt exist in undefined:

**Commmand:**
```bash
~/Projects/nf-debug/ng20$ npm run build host -- --configuration=development
```

**Error:**
```bash
> nf-debug@0.0.0 build
> ng build host --configuration=development

An unhandled exception occurred: Cannot read properties of undefined (reading 'split')
See "/tmp/ng-pWi9UK/angular-errors.log" for further details.
```

The fix creates a distinction between running in a server (like vite) or running in devmode. The builder checks if explicitly is defined if it is a devServer, if not, it checks if the target contains "serve", like the "serve-original" target. 

With this fix, it is possible to run "serve" in prod and dev, as well as "build". 