### PR TITLE
feat(nf): Share subpackages from used package in 'ignoreUnusedDeps'.

### DIFF
--- a/libs/native-federation-core/src/lib/config/with-native-federation.ts
+++ b/libs/native-federation-core/src/lib/config/with-native-federation.ts
@@ -7,6 +7,7 @@ import {
 } from './federation-config';
 import {
   isInSkipList,
+  PREPARED_UNUSED_DEPS_SKIP_LIST,
   PreparedSkipList,
   prepareSkipList,
 } from '../core/default-skip-list';
@@ -42,19 +43,9 @@ export function withNativeFederation(
 function filterShared(
   shared: Record<string, NormalizedSharedConfig>
 ): Record<string, NormalizedSharedConfig> {
-  const keys = Object.keys(shared).filter(
-    (k) => !k.startsWith('@angular/common/locales')
-  );
-
-  const filtered = keys.reduce(
-    (acc, curr) => ({
-      ...acc,
-      [curr]: shared[curr],
-    }),
-    {}
-  );
-
-  return filtered;
+  return Object.keys(shared)
+    .filter((k) => !isInSkipList(k, PREPARED_UNUSED_DEPS_SKIP_LIST))
+    .reduce((acc, c) => ({ ...acc, [c]: shared[c] }), {});
 }
 
 function normalizeShared(

--- a/libs/native-federation-core/src/lib/core/default-skip-list.ts
+++ b/libs/native-federation-core/src/lib/core/default-skip-list.ts
@@ -30,6 +30,14 @@ export const DEFAULT_SKIP_LIST: SkipList = [
 
 export const PREPARED_DEFAULT_SKIP_LIST = prepareSkipList(DEFAULT_SKIP_LIST);
 
+export const UNUSED_DEPS_SKIP_LIST: SkipList = [
+  (pkg) => pkg.startsWith('@angular/common/locales'),
+];
+
+export const PREPARED_UNUSED_DEPS_SKIP_LIST = prepareSkipList(
+  UNUSED_DEPS_SKIP_LIST
+);
+
 export type PreparedSkipList = {
   strings: Set<string>;
   functions: SkipFn[];


### PR DESCRIPTION
Closes #953.

Added check where subpackages from same collection are shared during removeUnusedDeps to prevent subtle mismatches between subpackages. 