### PR TITLE
chore(nf): fix double negation lint error in builder under nf lib

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -135,7 +135,7 @@ export async function* runBuilder(
   const write = true;
   const watch = nfOptions.watch;
 
-  if (!!options['buildTarget']) {
+  if (options['buildTarget']) {
     serverOptions = await normalizeOptions(
       context,
       context.target.project,


### PR DESCRIPTION
The pipeline for PR #965 failed while running `native-federation:lint`.
This PR fixes the only lint error in this library. Warnings not touched.