### PR TITLE
feat(nf): forward serve port for native federation lib

### DIFF
--- a/libs/native-federation/src/builders/build/builder.ts
+++ b/libs/native-federation/src/builders/build/builder.ts
@@ -117,14 +117,6 @@ export async function* runBuilder(
     return;
   }
 
-  let options = (await context.validateOptions(
-    {
-      ...targetOptions,
-      port: nfOptions.port || targetOptions['port'],
-    },
-    builder
-  )) as JsonObject & ApplicationBuilderOptions;
-
   /**
    * Explicitly defined as devServer or if the target contains "serve"
    */
@@ -132,6 +124,16 @@ export async function* runBuilder(
     typeof nfOptions.devServer !== 'undefined'
       ? !!nfOptions.devServer
       : target.target.includes('serve');
+
+  let options = (await context.validateOptions(
+    runServer
+      ? {
+          ...targetOptions,
+          port: nfOptions.port || targetOptions['port'],
+        }
+      : targetOptions,
+    builder
+  )) as JsonObject & ApplicationBuilderOptions;
 
   let serverOptions = null;
 


### PR DESCRIPTION
Forwards port set with `ng serve --port 4123` from `serve` target to `serve-original`.

If no port is provided, the fallback is the `serve-original` port, which is set via the `@angular-architects/native-federation:init --port` schematic.

If no port is set there either, Angular falls back to port 4200.

Closes #939