### PR TITLE
feat(native-federation): Add .mjs to esbuild resolveExtensions

### DIFF
--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -301,6 +301,7 @@ async function runEsbuild(
       ngJitMode: 'false',
     },
     ...(builderOptions.loader ? { loader: builderOptions.loader } : {}),
+    resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs']
   };
 
   const ctx = await esbuild.context(config);


### PR DESCRIPTION
This PR updates the angular-esbuild-adapter to include .mjs and .cjs in the resolveExtensions array for esbuild.

Why is this change needed?

We want to allow Angular libraries built with ng-packagr (which often output .mjs files) to be correctly consumed in a federated module setup.
Current error -
 INFO  Building federation artefacts
`✘ [ERROR] Could not resolve "./index"
    **/*.mjs:4:14:
      4 │ export * from './index';
`

Error: Build failed with 1 error:
**/*.mjs:4:14: ERROR: Could not resolve "./index"
    at failureErrorWithLog (/node_modules/@angular-architects/native-federation/node_modules/esbuild/lib/main.js:1467:15)

Without this change, esbuild may not correctly resolve the module imports, leading to build failures when trying to federate ng-packagr-built modules. This explicit addition ensures that .mjs files are recognized as valid module entry points.

Angular's source code for resolveExtensions array - https://github.com/search?q=repo%3Aangular%2Fangular-cli+Resolveextensions&type=code

