### PR TITLE
Add .mjs resolution to Native Federation esbuild adapter

### DIFF
--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -301,7 +301,7 @@ async function runEsbuild(
       ngJitMode: 'false',
     },
     ...(builderOptions.loader ? { loader: builderOptions.loader } : {}),
-    resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs']
+    resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs', '.json', '.jsx', '.css'],
   };
 
   const ctx = await esbuild.context(config);

--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -301,6 +301,7 @@ async function runEsbuild(
       ngJitMode: 'false',
     },
     ...(builderOptions.loader ? { loader: builderOptions.loader } : {}),
+    resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs']
   };
 
   const ctx = await esbuild.context(config);


### PR DESCRIPTION
## Summary
Add `resolveExtensions` to the NF Angular esbuild adapter so `.mjs` entrypoints are resolved alongside TS/JS

## Context
Shared/exposed packages that publish `index.mjs` fail to resolve during NF builds (esbuild error: “Could not resolve …”) because `.mjs` isn’t in the default extensions list.

 ## Testing 
Local NF build with a shared module that exposes an `index.mjs` now completes without resolution errors