### PR TITLE
feat(native-federation): including sass on styleOptions

### DIFF
--- a/libs/native-federation/src/utils/create-compiler-options.ts
+++ b/libs/native-federation/src/utils/create-compiler-options.ts
@@ -55,6 +55,7 @@ export function createCompilerPluginOptions(
         sourcemapOptions.styles && !sourcemapOptions.hidden ? 'linked' : false,
       outputNames,
       includePaths: stylePreprocessorOptions?.includePaths,
+      sass: stylePreprocessorOptions?.sass,
       externalDependencies,
       target,
       inlineStyleLanguage,


### PR DESCRIPTION
Supporting sass options from stylePreprocessorOptions.

Issue ref.: https://github.com/angular-architects/module-federation-plugin/issues/856