### PR TITLE
Fix: Separate dev and production metadata files to prevent cache overwrites

### DIFF
--- a/libs/native-federation-core/src/lib/core/bundle-shared.ts
+++ b/libs/native-federation-core/src/lib/core/bundle-shared.ts
@@ -38,7 +38,7 @@ export async function bundleShared(
 
   const bundleCache = cacheEntry(
     cacheOptions.pathToCache,
-    getFilename(cacheOptions.bundleName),
+    getFilename(cacheOptions.bundleName, fedOptions.dev),
   );
 
   if (fedOptions?.cacheExternalArtifacts) {

--- a/libs/native-federation-core/src/lib/utils/bundle-caching.ts
+++ b/libs/native-federation-core/src/lib/utils/bundle-caching.ts
@@ -8,8 +8,9 @@ import { logger } from '../utils/logger';
 export const getCachePath = (workspaceRoot: string, project: string) =>
   path.join(workspaceRoot, 'node_modules/.cache/native-federation', project);
 
-export const getFilename = (title: string) => {
-  return `${title}.meta.json`;
+export const getFilename = (title: string, dev?: boolean) => {
+  const devSuffix = dev ? '-dev' : '';
+  return `${title}${devSuffix}.meta.json`;
 };
 
 export const getChecksum = (


### PR DESCRIPTION
**Problem**
When running both production builds (ng build) and dev server (ng serve) for the same project, the dev server fails to serve federation chunk files. The chunks exist in the cache with -dev.js suffix, but are never copied to the dist folder because the metadata file lists production filenames (without -dev suffix). This causes module loading failures as remoteEntry.json references files that don't exist in the dist folder.

**Root Cause**
If I am not mistaken, in v3.4.x, the caching system was refactored to use a single metadata file (browser-shared.meta.json) for both dev and production builds. This causes production builds to overwrite the dev metadata:
- Production build creates chunks without -dev suffix and writes these filenames to browser-shared.meta.json
- Dev server reads the same browser-shared.meta.json which lists production filenames
- The copyFiles() function tries to copy files like _angular_core.XXX.js from cache
- These files don't exist in cache (only _angular_core.XXX-dev.js exists)
- The function silently skips missing files (line 55-57 in bundle-caching.js: if (fs.existsSync(cachedFile)))
- Result: No federation chunks are copied to dist folder at all

These 2 small changes should make sure dev and production builds maintain independent metadata with correct filenames.