### PR TITLE
fix(native-federation): Fix failing build caused by concurrent access to externals metadata.

### DIFF
--- a/libs/native-federation-core/src/lib/core/build-for-federation.ts
+++ b/libs/native-federation-core/src/lib/core/build-for-federation.ts
@@ -17,6 +17,7 @@ import { logger } from '../utils/logger';
 import { getCachePath } from './../utils/bundle-caching';
 import { normalizePackageName } from '../utils/normalize';
 import { AbortedError } from '../utils/errors';
+import { resolveProjectName } from '../utils/config-utils';
 
 export interface BuildParams {
   skipMappingsAndExposed: boolean;
@@ -64,15 +65,7 @@ export async function buildForFederation(
     ? describeExposed(config, fedOptions)
     : artefactInfo.exposes;
 
-  const normalizedCacheFolder = normalizePackageName(config.name);
-  if (normalizedCacheFolder.length < 1) {
-    logger.warn(
-      "Project name in 'federation.config.js' is empty, defaulting to 'shell' cache folder (could collide with other projects in the workspace).",
-    );
-  }
-  const cacheProjectFolder =
-    normalizedCacheFolder.length < 1 ? 'shell' : normalizedCacheFolder;
-
+  const cacheProjectFolder = resolveProjectName(config);
   const pathToCache = getCachePath(
     fedOptions.workspaceRoot,
     cacheProjectFolder,

--- a/libs/native-federation-core/src/lib/utils/config-utils.ts
+++ b/libs/native-federation-core/src/lib/utils/config-utils.ts
@@ -1,0 +1,14 @@
+import { NormalizedFederationConfig } from '../config/federation-config';
+import { logger } from './logger';
+import { normalizePackageName } from './normalize';
+
+export function resolveProjectName(config: NormalizedFederationConfig): string {
+  const normalizedProjectName = normalizePackageName(config.name);
+  if (normalizedProjectName.length < 1) {
+    logger.warn(
+      "Project name in 'federation.config.js' is empty, defaulting to 'shell' cache folder (could collide with other projects in the workspace).",
+    );
+  }
+
+  return normalizedProjectName.length < 1 ? 'shell' : normalizedProjectName;
+}


### PR DESCRIPTION
# Summary
The externals metadata are stored individually for each native federation build to prevent build errors. 

# Context

When running applications using e.g. `concurrently "ng serve mfe1" "ng serve mfe2" "ng serve mfe3" "ng serve vnf-host"` the host and all micro frontends are built and launched in parallel. Hence, externals metadata files are also processed in parallel.

Since the applications use the same dependency stack, different processes access the same files, which can result in empty files or exceptions such as `EBUSY: resource busy or locked.`

To avoid build errors, the externals metadata files should be processed and stored separately for each build.