### PR TITLE
fix(nf): fix typo in warning message for package usage

### DIFF
--- a/libs/native-federation-core/src/lib/utils/package-info.ts
+++ b/libs/native-federation-core/src/lib/utils/package-info.ts
@@ -372,7 +372,7 @@ export function _getPackageInfo(
 
   logger.warn('No entry point found for ' + packageName);
   logger.warn(
-    "If you don't need this package, skip it in your federation.config.js or consider moving it into depDependencies in your package.json",
+    "If you don't need this package, skip it in your federation.config.js or consider moving it into devDependencies in your package.json",
   );
 
   return null;


### PR DESCRIPTION
I propose correcting the message name according to npm; the correct name is "devDependencies" for packages that are only needed for local development and testing.

https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file