### PR TITLE
fix: define ngDevMode in dev builds to prevent ReferenceError

### DIFF
--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -314,7 +314,7 @@ async function runEsbuild(
       commonjsPlugin(),
     ],
     define: {
-      ...(!dev ? { ngDevMode: 'false' } : {}),
+      ngDevMode: dev ? 'true' : 'false',
       ngJitMode: 'false',
     },
     ...(builderOptions.loader ? { loader: builderOptions.loader } : {}),


### PR DESCRIPTION
## Summary

In dev mode, `ngDevMode` was not included in esbuild's `define` config. Angular's compiler emits bare `ngDevMode` references for `signal()`, `input()`, and `computed()` debug info. When these execute at module load time, they throw:

```
ReferenceError: ngDevMode is not defined
```

This one-line fix sets `ngDevMode` to `'true'` in dev builds (and keeps `'false'` for production), ensuring esbuild always replaces the identifier.

## The change

```diff
- ...(!dev ? { ngDevMode: 'false' } : {}),
+ ngDevMode: dev ? 'true' : 'false',
```

This also fixes the related issue where `isDevMode()` always returns `false` (#552), since `ngDevMode` is now correctly set to `true` during development.