### PR TITLE
fix(nf): redirect _not_found-chunk imports to primitives/di singleton

### DIFF
--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -339,7 +339,10 @@ async function runEsbuild(
                   ) {
                     return null;
                   }
-                  return { path: '@angular/core/primitives/di', external: true };
+                  return {
+                    path: '@angular/core/primitives/di',
+                    external: true,
+                  };
                 });
               },
             },

--- a/libs/native-federation/src/utils/angular-esbuild-adapter.ts
+++ b/libs/native-federation/src/utils/angular-esbuild-adapter.ts
@@ -312,6 +312,39 @@ async function runEsbuild(
         ? [createSharedMappingsPlugin(mappedPaths)]
         : []),
       commonjsPlugin(),
+      ...(kind === 'shared-package'
+        ? [
+            {
+              name: 'redirect-not-found-chunk-to-primitives-di',
+              setup(build: esbuild.PluginBuild) {
+                // When esbuild cannot resolve a module, it creates a synthetic
+                // `_not_found-chunk.mjs` stub that is re-exported by the real
+                // entry. If a later build step (e.g. the Angular linker) imports
+                // that stub while processing `@angular/core/primitives/di`, the
+                // stub tries to resolve as a bare specifier and causes a
+                // duplicate-singleton error at runtime because the real singleton
+                // from `primitives/di` is never used.
+                //
+                // Redirect every `_not_found-chunk` import to the canonical
+                // `@angular/core/primitives/di` package so only one instance of
+                // `_currentInjector` (and other primitives-di singletons) exists
+                // in the shared bundle.
+                build.onResolve({ filter: /_not_found-chunk/ }, (args) => {
+                  // Avoid infinite loop: if primitives/di itself imports the stub
+                  // (which should not happen, but guard just in case) return null
+                  // to let esbuild handle it normally.
+                  if (
+                    args.importer &&
+                    args.importer.includes('primitives-di')
+                  ) {
+                    return null;
+                  }
+                  return { path: '@angular/core/primitives/di', external: true };
+                });
+              },
+            },
+          ]
+        : []),
     ],
     define: {
       ngDevMode: dev ? 'true' : 'false',


### PR DESCRIPTION
Closes #1097

## What

Adds an esbuild `onResolve` plugin to `angular-esbuild-adapter.ts` that fires
only during `shared-package` builds. It intercepts any import matching
`_not_found-chunk` and redirects it to `@angular/core/primitives/di` (marked
as `external`), which is the canonical shared singleton that owns
`_currentInjector`.

The guard `args.importer.includes('primitives-di')` lets `primitives/di` itself
inline `_not_found-chunk.mjs` normally, preventing a circular dependency.

## Why

When `@angular/core` sub-paths (`rxjs-interop`, `primitives/di`, `primitives/signals`)
are configured with `build: 'separate'`, esbuild cannot mark `_not_found-chunk.mjs`
as external (it has no importmap entry), so it inlines an independent copy into each
artifact. At runtime every copy declares its own `_currentInjector = null`,
fragmenting Angular's injection context and causing `NG0203` errors even inside
valid injection contexts.

Redirecting to the shared `primitives/di` singleton ensures exactly one
`_currentInjector` variable exists at runtime.

## Affected file

`libs/native-federation/src/utils/angular-esbuild-adapter.ts`

## Test plan

- [ ] Host + remote app with `@angular/core`, `@angular/core/rxjs-interop` and
      `@angular/core/primitives/di` each configured as `build: 'separate'`
- [ ] `toObservable()` inside a constructor / `runInInjectionContext` no longer throws `NG0203`
- [ ] `inject()` calls in service constructors still resolve correctly
- [ ] Existing builds without `build: 'separate'` are unaffected (plugin only runs
      for `kind === 'shared-package'`)

## Workaround until merged

Apply via patch-package on `@angular-architects/native-federation`, targeting
`src/utils/angular-esbuild-adapter.js`.

Verified with `@angular-architects/native-federation@21.2.3` + `@angular/core@21.2.8`
in a zoneless Angular 21 application.