### PR TITLE
fix(nf): skip rewriteChunkImports for _angular_compiler artifacts

### DIFF
--- a/libs/native-federation-core/src/lib/utils/rewrite-chunk-imports.spec.ts
+++ b/libs/native-federation-core/src/lib/utils/rewrite-chunk-imports.spec.ts
@@ -1,0 +1,197 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  deriveInternalName,
+  INTERNAL_SCOPE,
+  isSourceFile,
+  rewriteChunkImports,
+} from './rewrite-chunk-imports';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeTempFile(name: string, content: string): string {
+  const filePath = path.join(os.tmpdir(), name);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+function readTempFile(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function removeTempFile(filePath: string): void {
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+}
+
+// ---------------------------------------------------------------------------
+// deriveInternalName
+// ---------------------------------------------------------------------------
+
+describe('deriveInternalName', () => {
+  it('converts a relative .js import to an @nf-internal bare specifier', () => {
+    expect(deriveInternalName('./chunk-ABC.js')).toBe(
+      `${INTERNAL_SCOPE}/chunk-ABC`,
+    );
+  });
+
+  it('converts a relative .mjs import', () => {
+    expect(deriveInternalName('./chunk-XYZ.mjs')).toBe(
+      `${INTERNAL_SCOPE}/chunk-XYZ`,
+    );
+  });
+
+  it('converts a relative .cjs import', () => {
+    expect(deriveInternalName('./chunk-CJS.cjs')).toBe(
+      `${INTERNAL_SCOPE}/chunk-CJS`,
+    );
+  });
+
+  it('handles a name without a leading ./', () => {
+    expect(deriveInternalName('chunk-NO-PREFIX.js')).toBe(
+      `${INTERNAL_SCOPE}/chunk-NO-PREFIX`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSourceFile
+// ---------------------------------------------------------------------------
+
+describe('isSourceFile', () => {
+  it('returns true for .js files', () => {
+    expect(isSourceFile('bundle.js')).toBe(true);
+  });
+
+  it('returns true for .mjs files', () => {
+    expect(isSourceFile('bundle.mjs')).toBe(true);
+  });
+
+  it('returns true for .cjs files', () => {
+    expect(isSourceFile('bundle.cjs')).toBe(true);
+  });
+
+  it('returns false for .ts files', () => {
+    expect(isSourceFile('bundle.ts')).toBe(false);
+  });
+
+  it('returns false for .json files', () => {
+    expect(isSourceFile('metadata.json')).toBe(false);
+  });
+
+  it('returns false for .map files', () => {
+    expect(isSourceFile('bundle.js.map')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteChunkImports — normal rewriting
+// ---------------------------------------------------------------------------
+
+describe('rewriteChunkImports — normal files', () => {
+  let tmpFile: string;
+
+  afterEach(() => removeTempFile(tmpFile));
+
+  it('rewrites a static import from a relative path to @nf-internal', () => {
+    tmpFile = writeTempFile(
+      'shared-bundle.ABC123.js',
+      `import { foo } from "./chunk-ABC123.js";\nexport { foo };\n`,
+    );
+
+    rewriteChunkImports(tmpFile);
+
+    expect(readTempFile(tmpFile)).toContain(
+      `"${INTERNAL_SCOPE}/chunk-ABC123"`,
+    );
+    expect(readTempFile(tmpFile)).not.toContain('./chunk-ABC123.js');
+  });
+
+  it('rewrites a re-export from a relative path to @nf-internal', () => {
+    tmpFile = writeTempFile(
+      'shared-bundle.DEF456.js',
+      `export { bar } from "./chunk-DEF456.js";\n`,
+    );
+
+    rewriteChunkImports(tmpFile);
+
+    expect(readTempFile(tmpFile)).toContain(
+      `"${INTERNAL_SCOPE}/chunk-DEF456"`,
+    );
+    expect(readTempFile(tmpFile)).not.toContain('./chunk-DEF456.js');
+  });
+
+  it('rewrites a dynamic import from a relative path to @nf-internal', () => {
+    tmpFile = writeTempFile(
+      'shared-bundle.GHI789.js',
+      `const m = import("./chunk-GHI789.js");\n`,
+    );
+
+    rewriteChunkImports(tmpFile);
+
+    expect(readTempFile(tmpFile)).toContain(
+      `"${INTERNAL_SCOPE}/chunk-GHI789"`,
+    );
+    expect(readTempFile(tmpFile)).not.toContain('./chunk-GHI789.js');
+  });
+
+  it('does not rewrite absolute or bare specifier imports', () => {
+    const original = `import { x } from "@angular/core";\nimport { y } from "/absolute.js";\n`;
+    tmpFile = writeTempFile('shared-bundle.JKL.js', original);
+
+    rewriteChunkImports(tmpFile);
+
+    const result = readTempFile(tmpFile);
+    expect(result).toContain('@angular/core');
+    expect(result).toContain('/absolute.js');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteChunkImports — _angular_compiler guard
+// ---------------------------------------------------------------------------
+
+describe('rewriteChunkImports — _angular_compiler files', () => {
+  it('does NOT rewrite imports when the file name contains _angular_compiler', () => {
+    // This guard is critical: _angular_compiler artifacts are loaded via native
+    // import() when the host sets esmsInitOptions.skip to bypass es-module-shims
+    // for large files. Native import() cannot resolve @nf-internal/* bare
+    // specifiers, so their chunk imports must stay as relative paths.
+    const original = `import { __spreadValues } from "./chunk-WO6WBJ4Z.js";\n`;
+    const tmpFile = writeTempFile(
+      '_angular_compiler.WM-0EiHxmR-dev.js',
+      original,
+    );
+
+    rewriteChunkImports(tmpFile);
+
+    expect(readTempFile(tmpFile)).toBe(original);
+    removeTempFile(tmpFile);
+  });
+
+  it('does NOT rewrite when _angular_compiler appears anywhere in the basename', () => {
+    const original = `export * from "./chunk-ABC.js";\n`;
+    const tmpFile = writeTempFile(
+      'prefix_angular_compiler_suffix.hash.js',
+      original,
+    );
+
+    rewriteChunkImports(tmpFile);
+
+    expect(readTempFile(tmpFile)).toBe(original);
+    removeTempFile(tmpFile);
+  });
+
+  it('DOES rewrite files whose name only contains "angular" but not "_angular_compiler"', () => {
+    const original = `import { x } from "./chunk-XXYYZZ.js";\n`;
+    const tmpFile = writeTempFile('angular-forms.hash.js', original);
+
+    rewriteChunkImports(tmpFile);
+
+    expect(readTempFile(tmpFile)).toContain(`${INTERNAL_SCOPE}/chunk-XXYYZZ`);
+    removeTempFile(tmpFile);
+  });
+});

--- a/libs/native-federation-core/src/lib/utils/rewrite-chunk-imports.ts
+++ b/libs/native-federation-core/src/lib/utils/rewrite-chunk-imports.ts
@@ -5,6 +5,15 @@ import * as path from 'path';
 export const INTERNAL_SCOPE = '@nf-internal';
 
 export function rewriteChunkImports(filePath: string) {
+  // `_angular_compiler` artifacts are loaded via native import() when the host
+  // sets `esmsInitOptions.skip` (e.g. `/_angular_compiler\\.`). Native import()
+  // bypasses es-module-shims and therefore cannot resolve `@nf-internal/*` bare
+  // specifiers. Keeping their original relative `./chunk-X.js` imports lets the
+  // browser resolve them natively relative to the served artifact URL.
+  if (path.basename(filePath).includes('_angular_compiler')) {
+    return;
+  }
+
   const sourceCode = fs.readFileSync(filePath, 'utf-8');
 
   const sourceFile = ts.createSourceFile(


### PR DESCRIPTION
Closes #1099

## What

Adds a guard at the top of `rewriteChunkImports()` in `rewrite-chunk-imports.ts`
that returns early when the file's basename contains `_angular_compiler`.
Their chunk imports remain as relative `./chunk-X.js` paths instead of being
converted to `@nf-internal/chunk-X` bare specifiers.

Also adds a unit-test suite for `rewrite-chunk-imports.ts` covering:
- `deriveInternalName` — `.js`, `.mjs`, `.cjs` variants and the no-prefix case
- `isSourceFile` — accepted and rejected extensions
- Normal rewriting — static imports, re-exports, dynamic imports, bare/absolute specifiers (untouched)
- `_angular_compiler` guard — file not modified, partial-name variants, false-positive guard

## Why

`rewriteChunkImports` converts relative chunk imports to `@nf-internal/*`
bare specifiers so es-module-shims can resolve them via the importmap.
This works for all files loaded through es-module-shims.

However, `@angular/compiler` (~1.1 MB, ~29 000 lines) overflows the WASM
module lexer in es-module-shims v2, causing the app to hang on bootstrap.
The standard mitigation is to add `esmsInitOptions.skip: "/_angular_compiler\\."` 
in `angular.json`, which makes those files load via native `import()` —
bypassing es-module-shims entirely.

Native `import()` cannot resolve `@nf-internal/*` bare specifiers, so the
rewritten imports produce:

```
TypeError: Failed to resolve module specifier '@nf-internal/chunk-<hash>'.
Relative references must start with either "/", "./", or "../".
```

Keeping the imports relative for `_angular_compiler` artifacts allows the
browser to resolve them natively relative to the served artifact URL.

The guard is placed inside `rewriteChunkImports` (rather than the caller in
`bundle-shared.ts`) so that any direct call to `rewriteChunkImports` is also
protected, and so the behaviour can be unit-tested directly.

## Affected files

- `libs/native-federation-core/src/lib/utils/rewrite-chunk-imports.ts` — guard added
- `libs/native-federation-core/src/lib/utils/rewrite-chunk-imports.spec.ts` — new test suite

## Test plan

- [ ] `_angular_compiler` artifact file is not modified by `rewriteChunkImports`
- [ ] Non-`_angular_compiler` artifacts still have their relative imports rewritten to `@nf-internal/*`
- [ ] Host configured with `esmsInitOptions.skip: "/_angular_compiler\\."` boots without `TypeError: Failed to resolve module specifier '@nf-internal/chunk-*'`
- [ ] Builds **without** `esmsInitOptions.skip` are unaffected

## Workaround until merged

Apply via `patch-package` on `@softarc/native-federation`, targeting
`src/lib/utils/rewrite-chunk-imports.js`.

Verified with `@softarc/native-federation@3.5.5` + `es-module-shims@2.x`
in an Angular 21 zoneless application.