### PR TITLE
fix(native-federation): content-hash shared entry filenames to prevent stale-cache chunk resolution

### DIFF
--- a/libs/native-federation-core/src/lib/core/bundle-shared.ts
+++ b/libs/native-federation-core/src/lib/core/bundle-shared.ts
@@ -22,6 +22,7 @@ import {
   getChecksum,
   getFilename,
 } from './../utils/bundle-caching';
+import { contentHashedName } from '../utils/content-hashed-name';
 
 export async function bundleShared(
   sharedBundles: Record<string, NormalizedSharedConfig>,
@@ -86,12 +87,16 @@ export async function bundleShared(
     fedOptions.outputPath,
   );
 
-  const expectedResults = allEntryPoints.map((ep) =>
-    path.join(fullOutputPath, ep.outName),
-  );
-  const entryPoints = allEntryPoints.filter(
-    (ep) => !fs.existsSync(path.join(cacheOptions.pathToCache, ep.outName)),
-  );
+  // In production always rebuild the shared entries so they stay consistent with the
+  // freshly built (content-hashed) chunk graph. The filename-existence shortcut below
+  // is content-blind: because the entry name is derived from the package version (see
+  // createOutName), a previously cached entry could be reused even though the chunks it
+  // imports have been renamed, yielding a dist that references chunks it never emitted.
+  const entryPoints = fedOptions.dev
+    ? allEntryPoints.filter(
+        (ep) => !fs.existsSync(path.join(cacheOptions.pathToCache, ep.outName)),
+      )
+    : allEntryPoints;
 
   // If we build for the browser and don't remote unused deps from the shared config,
   // we need to exclude typical node libs to avoid compilation issues
@@ -120,6 +125,44 @@ export async function bundleShared(
 
     const cachedFiles = bundleResult.map((br) => path.basename(br.fileName));
     rewriteImports(cachedFiles, cacheOptions.pathToCache);
+
+    // Re-hash each shared entry from its FINAL content (after import rewriting) so the
+    // file name changes if and only if the content changes. createOutName() derives the
+    // name from the package version only, which is not a content key once the shared
+    // chunk graph shifts. Chunks are already content-hashed by the bundler, so we leave
+    // them untouched. Skipped in dev to keep watch/HMR file names stable.
+    if (!fedOptions.dev) {
+      for (const ep of allEntryPoints) {
+        const oldPath = path.join(cacheOptions.pathToCache, ep.outName);
+        if (!fs.existsSync(oldPath)) {
+          continue;
+        }
+        const newName = contentHashedName(ep.outName, fs.readFileSync(oldPath));
+        if (newName === ep.outName) {
+          continue;
+        }
+        fs.renameSync(oldPath, path.join(cacheOptions.pathToCache, newName));
+        const mapOld = `${oldPath}.map`;
+        if (fs.existsSync(mapOld)) {
+          fs.renameSync(
+            mapOld,
+            path.join(cacheOptions.pathToCache, `${newName}.map`),
+          );
+        }
+        // Keep bundleResult in sync so chunk detection and the persisted file list
+        // (used by copyFiles) reference the new name.
+        for (const br of bundleResult) {
+          const baseName = path.basename(br.fileName);
+          if (baseName === ep.outName || baseName === `${ep.outName}.map`) {
+            br.fileName = path.join(
+              path.dirname(br.fileName),
+              baseName.replace(ep.outName, newName),
+            );
+          }
+        }
+        ep.outName = newName;
+      }
+    }
   } catch (e) {
     logger.error('Error bundling shared npm package ');
     if (e instanceof Error) {
@@ -152,7 +195,9 @@ export async function bundleShared(
     throw e;
   }
 
-  const outFileNames = [...expectedResults];
+  const outFileNames = allEntryPoints.map((ep) =>
+    path.join(fullOutputPath, ep.outName),
+  );
 
   const result = buildResult(packageInfos, sharedBundles, outFileNames);
 

--- a/libs/native-federation-core/src/lib/utils/content-hashed-name.spec.ts
+++ b/libs/native-federation-core/src/lib/utils/content-hashed-name.spec.ts
@@ -1,0 +1,49 @@
+import { contentHashedName } from './content-hashed-name';
+
+describe('contentHashedName', () => {
+  const entry = '_acme_ui_core_utils.WBGsfdhQ1R.js';
+
+  it('appends a content hash and keeps the original base name', () => {
+    const name = contentHashedName(
+      entry,
+      'import "@nf-internal/chunk-BL4UGAOX";',
+    );
+    expect(name).toMatch(
+      /^_acme_ui_core_utils\.WBGsfdhQ1R\.[0-9a-f]{12}\.js$/,
+    );
+  });
+
+  it('is stable for identical content', () => {
+    const content = 'import "@nf-internal/chunk-BL4UGAOX";';
+    expect(contentHashedName(entry, content)).toBe(
+      contentHashedName(entry, content),
+    );
+  });
+
+  it('changes when the content changes (the bug this fixes)', () => {
+    // Same version-based entry name, but an imported chunk was renamed -> different bytes.
+    const before = contentHashedName(
+      entry,
+      'import "@nf-internal/chunk-BL4UGAOX";',
+    );
+    const after = contentHashedName(
+      entry,
+      'import "@nf-internal/chunk-I76J64FX";',
+    );
+    expect(after).not.toBe(before);
+  });
+
+  it('is idempotent (re-hashing strips a previously applied content hash)', () => {
+    const content = 'export const x = 1;';
+    const once = contentHashedName(entry, content);
+    const twice = contentHashedName(once, content);
+    expect(twice).toBe(once);
+  });
+
+  it('accepts Buffer content', () => {
+    const buf = Buffer.from('export const x = 1;');
+    expect(contentHashedName(entry, buf)).toBe(
+      contentHashedName(entry, 'export const x = 1;'),
+    );
+  });
+});

--- a/libs/native-federation-core/src/lib/utils/content-hashed-name.ts
+++ b/libs/native-federation-core/src/lib/utils/content-hashed-name.ts
@@ -1,0 +1,29 @@
+import * as crypto from 'crypto';
+
+/**
+ * Produces a content-addressed file name for a shared-package entry.
+ *
+ * `createOutName()` (see bundle-shared.ts) derives the entry file name from the package
+ * *version* + entry path + config, not from its emitted bytes. Because the rewritten
+ * `@nf-internal/chunk-*` imports point into a chunk graph shared across all shared
+ * packages, an entry's content can change (an imported chunk is renamed) while its
+ * version-based name stays the same — so caches serve a stale entry that imports a chunk
+ * the current import map no longer lists ("Unable to resolve specifier
+ * '@nf-internal/chunk-...'"). Hashing the final content makes the file name change if and
+ * only if the content changes.
+ *
+ * Idempotent: a previously appended content hash is stripped before re-hashing, so
+ * running this twice on the same bytes yields the same name.
+ */
+export function contentHashedName(
+  outName: string,
+  content: Buffer | string,
+): string {
+  const contentHash = crypto
+    .createHash('md5')
+    .update(content)
+    .digest('hex')
+    .substring(0, 12);
+  const base = outName.replace(/\.js$/, '').replace(/\.[0-9a-f]{12}$/, '');
+  return `${base}.${contentHash}.js`;
+}


### PR DESCRIPTION
## Summary

Shared-package entry files (e.g. `_acme_ui_core_utils.<hash>.js`) are named by `createOutName()` from the package **version + entry-point path + config** — **not from their emitted content**. The content of those files is largely `@nf-internal/chunk-*` imports that resolve, via `remoteEntry.json` / `importmap.json`, into a code-split chunk graph **shared across all `share()` packages**. When that graph changes (any shared dep changes, or esbuild moves a split boundary), the chunk content hashes change (`chunk-BL4UGAOX` → `chunk-I76J64FX`) and the entry file's body changes — **but its version-based filename does not**.

A browser/CDN that cached the previous build's entry then serves a file whose `@nf-internal/chunk-*` imports no longer exist in the always-fresh `remoteEntry.json`, producing:

```
Error: Unable to resolve specifier '@nf-internal/chunk-BL4UGAOX'
  imported from https://app.example.com/.../_acme_ui_core_utils.WBGsfdhQ1R.js
```

This is "same filename, different content across builds" — a cache-poisoning hazard no cache header can fix, because the filename is not a content key.

## Root cause

`libs/native-federation-core/src/lib/core/bundle-shared.ts`:

```ts
function createOutName(pi, configState, fedOptions, encName) {
  const hashBase = pi.version + '_' + pi.entryPoint + '_' + configState; // no content
  const hash = calcHash(hashBase);
  return fedOptions.dev ? `${encName}.${hash}-dev.js` : `${encName}.${hash}.js`;
}
```

`hashBase` excludes the emitted bytes and the rewritten `@nf-internal/chunk-*` import list, so two builds of the same package version produce the **identical** entry filename even when the bundled output differs. The split chunks, by contrast, are esbuild-content-hashed (`chunk-[hash]`), so they *do* change with content — creating the name/content mismatch.

A second, compounding factor in the same file — the per-entry reuse is content-blind:

```ts
const entryPoints = allEntryPoints.filter(
  (ep) => !fs.existsSync(path.join(cacheOptions.pathToCache, ep.outName)),
);
```

If a file with the version-based name already exists in `node_modules/.cache/native-federation/<project>`, the entry is **not rebuilt**, so a previously-cached entry (importing old chunk names) can be emitted alongside a freshly-rebuilt chunk set that no longer contains those chunks — an internally inconsistent `dist` from a single build.

### Note: bumping the package version is not a workaround

The triggering package's own version need not change. An entry's content drifts because of changes **elsewhere in the shared set** that rename the shared chunks it imports. A package pinned to an immutable version (e.g. published to a registry that forbids overwrites) still gets new entry-file content under the same filename.

## Evidence

Comparing the cached entry against a fresh build, the file differs by exactly one line while the filename hash is unchanged:

```diff
- import { c as k } from "@nf-internal/chunk-BL4UGAOX";
+ import { c as k } from "@nf-internal/chunk-I76J64FX";
```

The fresh `remoteEntry.json` lists `chunk-I76J64FX` but not `chunk-BL4UGAOX`; the browser-cached `_acme_ui_core_utils.<sameHash>.js` still imports `chunk-BL4UGAOX` → unresolved specifier.

## Change

- Extracts a pure, idempotent `contentHashedName(outName, content)` helper (`utils/content-hashed-name.ts`).
- After `rewriteImports`, in production, re-hashes each shared entry file from its **final content** and renames it, keeping `bundleResult`, `remoteEntry.json` and `importmap.json` in sync. The filename now changes **iff** the content changes. Chunks are already content-hashed and left untouched.
- Restricts the content-blind per-entry rebuild-skip to dev builds, so production output is always internally consistent with the emitted chunk graph.
- Dev/watch/HMR behaviour is unchanged (`!fedOptions.dev` guards).

## Tests

`utils/content-hashed-name.spec.ts` asserts the core property: the name is stable for identical content, **changes when content changes**, is idempotent, and accepts `Buffer`/`string`. `tsc --noEmit` is clean.

## Impact / compatibility

- Output filenames for shared packages gain a content hash segment; consumers resolve everything through `remoteEntry.json`/`importmap.json`, which are updated in the same pass, so no runtime references break.
- Reproduces on `main`; affects `@angular-architects/native-federation` users as well (the Angular wrapper delegates here).
