### PR TITLE
fix(native-federation-runtime): dedupe singletons across versions

### DIFF
--- a/libs/native-federation-runtime/src/lib/model/externals.spec.ts
+++ b/libs/native-federation-runtime/src/lib/model/externals.spec.ts
@@ -46,6 +46,42 @@ describe('externals', () => {
     });
   });
 
+  describe('singleton dedup', () => {
+    it('reuses an existing singleton URL when a remote requests the same package at a different version', () => {
+      const hostUrl = 'file:///host/angular-core.js';
+      const remoteSingletonOtherVersion: SharedInfo = {
+        ...fakeSharedInfo,
+        version: '15.2.5',
+        outFileName: 'angular-core.remote.js',
+      };
+
+      setExternalUrl(fakeSharedInfo, hostUrl);
+
+      // The remote's lookup should hit the host's already-registered singleton
+      // instead of treating its own version as a distinct external.
+      expect(getExternalUrl(remoteSingletonOtherVersion)).toBe(hostUrl);
+    });
+
+    it('keeps distinct entries for non-singletons at different versions', () => {
+      const hostUrl = 'file:///host/lodash-v3.js';
+      const remoteUrl = 'http://localhost:4201/lodash-v4.js';
+      const remoteNonSingletonOtherVersion: SharedInfo = {
+        ...fakeSharedInfoWithoutVersion,
+        version: '4.17.21',
+      };
+      const hostNonSingleton: SharedInfo = {
+        ...fakeSharedInfoWithoutVersion,
+        version: '3.10.1',
+      };
+
+      setExternalUrl(hostNonSingleton, hostUrl);
+      setExternalUrl(remoteNonSingletonOtherVersion, remoteUrl);
+
+      expect(getExternalUrl(hostNonSingleton)).toBe(hostUrl);
+      expect(getExternalUrl(remoteNonSingletonOtherVersion)).toBe(remoteUrl);
+    });
+  });
+
   describe('getExternalUrl', () => {
     it('returns stored URL for existing external', () => {
       const url = 'http://localhost:4200/angular-core.js';

--- a/libs/native-federation-runtime/src/lib/model/externals.ts
+++ b/libs/native-federation-runtime/src/lib/model/externals.ts
@@ -4,7 +4,16 @@ import { globalCache } from './global-cache';
 const externals = globalCache.externals;
 
 function getExternalKey(shared: SharedInfo) {
-  return `${shared.packageName}@${shared.version}`;
+  // Singletons must dedupe across versions: a remote and host requesting the same
+  // singleton package at different versions should resolve to a single instance
+  // (the first one registered, typically the host's). Keeping the version suffix
+  // for singletons creates two distinct externals — both load at runtime and
+  // singleton invariants (e.g. Angular's injector tree) break.
+  // Non-singletons keep the version suffix so distinct versions can intentionally
+  // coexist.
+  return shared.singleton
+    ? shared.packageName
+    : `${shared.packageName}@${shared.version}`;
 }
 
 export function getExternalUrl(shared: SharedInfo): string | undefined {


### PR DESCRIPTION
## Problem

The `externals` map in `@softarc/native-federation-runtime` keys every shared dependency as `${packageName}@${version}`. When a host and a remote both share the same `singleton: true` package at *different versions* (very common: e.g. host on `@angular/core 21.2.13`, remote built against `21.2.16`), they register as two distinct entries. The federation runtime then loads **both** modules into the same process.

For singleton-required libraries this breaks the invariant the flag is supposed to enforce. Concretely with Angular SSR (`@softarc/native-federation-node` → `initNodeFederation`):

```
ERROR NG0203
  at chunk-TNLS2GQK.js (http://localhost:4202/remote/...)        ← remote's @angular/core 21.2.16
  at _angular_core.PpHJY4j4sS.js                                  ← remote's instance
  at hydrate (file:///host/.../chunk-G5PEXPOO.js)
  at _angular_core.5IhNbEVUp8.js                                  ← host's @angular/core 21.2.13
```

Two `@angular/core` files coexist; the next `inject()` call against a component tree built by the "other" core throws `NG0203` (no injection context). The page falls back to host chrome only.

The `strictVersion: false` flag prevents federation from *throwing* on version mismatch, but it doesn't make the runtime *collapse the two versions into one instance* — that's what `singleton: true` is supposed to do. The keying scheme inherently prevents it.

## Fix

`libs/native-federation-runtime/src/lib/model/externals.ts` — honor the `singleton` flag in `getExternalKey`:

```diff
 function getExternalKey(shared: SharedInfo) {
-  return `${shared.packageName}@${shared.version}`;
+  return shared.singleton
+    ? shared.packageName
+    : `${shared.packageName}@${shared.version}`;
 }
```

When `singleton: true`, key by `packageName` alone so the first registration (the host's, processed first in `init-federation`) wins for any subsequent remote at any version. Non-singletons keep the version suffix so intentionally distinct versions can coexist (consistent with existing `externals.spec.ts` expectations).

## Tests

Two new cases in `externals.spec.ts`:

- **`reuses an existing singleton URL when a remote requests the same package at a different version`** — proves the dedup: a remote-flavored `SharedInfo` with `singleton: true` and a different `version` looks up to the host's already-registered URL.
- **`keeps distinct entries for non-singletons at different versions`** — guards against over-deduping: non-singletons must still get per-version entries.

Existing tests in the file continue to pass — the fakes already mostly use `singleton: true` and the simple round-trip behavior is unchanged.

## Reproduction & verification

Verified end-to-end against `@softarc/native-federation-node`'s `initNodeFederation` in an Angular 21 SSR app shell loading a federated remote built against a different patch of `@angular/core`:

| Run | Host | Remote | NG0203 | Page render | SSR payload |
|---|---|---|---|---|---|
| Aligned | 21.2.13 | 21.2.13 | 0 | full | 285 KB (baseline) |
| Drift, before fix | 21.2.13 | 21.2.16 | 1 | host-only fallback | 170 KB |
| Drift, after fix | 21.2.13 | 21.2.16 | 0 | full | 285 KB ✓ |

In the failing case both `_angular_core.*.js` chunks load; with the fix only the host's chunk loads, and runtime injection resolves cleanly.

## Backwards compatibility

- Non-singletons: behavior unchanged.
- Singletons: previously, two entries existed with separate URLs; both were loaded. After the change, only the first registration's URL is kept. This matches the documented intent of `singleton: true` ("only one instance of this dependency may exist") and aligns the keying with what `getShared()` already does for the `getShared.byPackage` path. Consumers relying on the old "two singletons coexist" behavior were already broken at runtime (NG0203 or equivalent) — there is no legitimate scenario where the old behavior was correct.