### PR TITLE
fix(native-federation): honour absolute outputPath when writing federation artifacts

### DIFF
--- a/libs/native-federation-core/src/lib/core/bundle-shared.ts
+++ b/libs/native-federation-core/src/lib/core/bundle-shared.ts
@@ -48,7 +48,7 @@ export async function bundleShared(
         `Checksum of ${cacheOptions.bundleName} matched, Skipped artifact bundling`,
       );
       bundleCache.copyFiles(
-        path.join(fedOptions.workspaceRoot, fedOptions.outputPath),
+        path.resolve(fedOptions.workspaceRoot, fedOptions.outputPath),
       );
       return cacheMetadata.externals;
     }
@@ -81,7 +81,7 @@ export async function bundleShared(
     return { fileName: pi.entryPoint, outName };
   });
 
-  const fullOutputPath = path.join(
+  const fullOutputPath = path.resolve(
     fedOptions.workspaceRoot,
     fedOptions.outputPath,
   );
@@ -174,7 +174,7 @@ export async function bundleShared(
   });
 
   bundleCache.copyFiles(
-    path.join(fedOptions.workspaceRoot, fedOptions.outputPath),
+    path.resolve(fedOptions.workspaceRoot, fedOptions.outputPath),
   );
 
   return result;

--- a/libs/native-federation-core/src/lib/core/write-federation-info.ts
+++ b/libs/native-federation-core/src/lib/core/write-federation-info.ts
@@ -7,7 +7,7 @@ export function writeFederationInfo(
   federationInfo: FederationInfo,
   fedOptions: FederationOptions,
 ) {
-  const metaDataPath = path.join(
+  const metaDataPath = path.resolve(
     fedOptions.workspaceRoot,
     fedOptions.outputPath,
     'remoteEntry.json',

--- a/libs/native-federation-core/src/lib/core/write-import-map.ts
+++ b/libs/native-federation-core/src/lib/core/write-import-map.ts
@@ -15,7 +15,7 @@ export function writeImportMap(
   }, {});
 
   const importMap = { imports };
-  const importMapPath = path.join(
+  const importMapPath = path.resolve(
     fedOption.workspaceRoot,
     fedOption.outputPath,
     'importmap.json',

--- a/libs/native-federation/src/plugin/index.ts
+++ b/libs/native-federation/src/plugin/index.ts
@@ -56,7 +56,7 @@ const configureDevServer = async (
   await federationBuilder.build();
 
   const op = params.options;
-  const dist = path.join(op.workspaceRoot, op.outputPath);
+  const dist = path.resolve(op.workspaceRoot, op.outputPath);
   server.middlewares.use(serveFromDist(dist, fedInfo));
 };
 

--- a/libs/native-federation/src/utils/updateIndexHtml.ts
+++ b/libs/native-federation/src/utils/updateIndexHtml.ts
@@ -7,7 +7,10 @@ export function updateIndexHtml(
   fedOptions: FederationOptions,
   nfOptions: NfBuilderSchema,
 ) {
-  const outputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
+  const outputPath = path.resolve(
+    fedOptions.workspaceRoot,
+    fedOptions.outputPath,
+  );
   const indexPathCands = [
     path.join(outputPath, '../server/index.server.html'),
     path.join(outputPath, 'index.html'),


### PR DESCRIPTION
Closes #1117.

### Problem

The federation output directory is resolved with `path.join(fedOptions.workspaceRoot, fedOptions.outputPath)` in several places. `path.join()` concatenates its segments, so when `outputPath` is **absolute** the result becomes `workspaceRoot + outputPath` — a bogus nested directory — instead of `outputPath`.

When an absolute output path is used (e.g. `ng build --output-path <abs>`, common in CI), `remoteEntry.json`, `importmap.json` and the shared bundles are written outside the configured output directory. The `@angular/build` application builder honours the absolute path for the app bundles, so the app files and the federation artifacts end up in different directories and the remote fails to load at runtime (`remoteEntry.json` 404/403, `Unable to resolve specifier` for shared deps).

It works with relative output paths, which is why it usually only surfaces in CI.

### Fix

Replace `path.join(workspaceRoot, outputPath)` with `path.resolve(workspaceRoot, outputPath)` at every site that combines the two. `path.resolve` is identical to `join` for relative paths but correctly honours an absolute `outputPath`.

**`native-federation-core`:**
- `write-federation-info.ts` (`remoteEntry.json`)
- `write-import-map.ts` (`importmap.json`)
- `bundle-shared.ts` (shared-bundle copy + output path, 3 sites)

**`native-federation` (adapter):**
- `utils/updateIndexHtml.ts` (locating `index.html`)
- `plugin/index.ts` (dev-server serve directory)

`builders/build/builder.ts` was intentionally left unchanged: its `path.join(outputOptions.base, 'browser')` already starts from an absolute base, so it is not affected.

### Verification

Building a native-federation remote with an absolute `--output-path` now writes `remoteEntry.json`, `importmap.json` and the shared bundles into `<outputPath>/browser` alongside the app bundles, instead of a nested `<workspaceRoot>/<outputPath>/browser` directory. Relative output paths are unaffected (`resolve` == `join` for them).


### AI Usage Disclosure

I used Claude Opus 4.8 to identify and fix this issue.